### PR TITLE
fixed: input field is numerical when should be texual

### DIFF
--- a/lib/Components/settings_text_field.dart
+++ b/lib/Components/settings_text_field.dart
@@ -39,7 +39,7 @@ class _SettingsTextFieldState extends State<SettingsTextField> {
             color: ThemeProvider.theme.textTheme.bodyText1?.color,
           ),
           keyboardType:
-              (!widget.isText) ? TextInputType.text : TextInputType.number,
+              (widget.isText) ? TextInputType.text : TextInputType.number,
           decoration: InputDecoration(
             floatingLabelBehavior: FloatingLabelBehavior.always,
             filled: true,

--- a/lib/Pages/settings_screen.dart
+++ b/lib/Pages/settings_screen.dart
@@ -152,7 +152,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   dht: clientSettingsModel.clientSettings.dht,
                   dhtPort: clientSettingsModel.clientSettings.dhtPort,
                   directoryDefault:
-                      clientSettingsModel.clientSettings.directoryDefault,
+                      defaultDownloadDirectoryController.text,
                   networkHttpMaxOpen:
                       clientSettingsModel.clientSettings.networkHttpMaxOpen,
                   networkLocalAddress:

--- a/lib/Pages/settings_screen.dart
+++ b/lib/Pages/settings_screen.dart
@@ -151,8 +151,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ClientSettingsModel newClientSettingsModel = new ClientSettingsModel(
                   dht: clientSettingsModel.clientSettings.dht,
                   dhtPort: clientSettingsModel.clientSettings.dhtPort,
-                  directoryDefault:
-                      defaultDownloadDirectoryController.text,
+                  directoryDefault: defaultDownloadDirectoryController.text,
                   networkHttpMaxOpen:
                       clientSettingsModel.clientSettings.networkHttpMaxOpen,
                   networkLocalAddress:


### PR DESCRIPTION
Fixes #56 

Keyboard of input fields in settings page are not set correctly.
for alphabetic, it's showing numeric and vice versa.
Fixed this issue. Now for alphabetic will show alphabetic and for numerical will show numerical

Screenshots of the changes (If any) -

before:
![Simulator Screen Shot - iPhone 13 - 2022-01-30 at 15 23 35](https://user-images.githubusercontent.com/52542371/151694974-739c3d90-a469-49fe-a4ca-5f1c2d53e365.png)

after:
![Simulator Screen Shot - iPhone 13 - 2022-01-30 at 15 03 08](https://user-images.githubusercontent.com/52542371/151694917-9a0470c2-0144-418a-98ef-7b8f45f1ddb7.png)

