### PR TITLE
in dark mode, label will be more visible

### DIFF
--- a/lib/Components/settings_text_field.dart
+++ b/lib/Components/settings_text_field.dart
@@ -29,7 +29,7 @@ class _SettingsTextFieldState extends State<SettingsTextField> {
         Text(
           widget.labelText,
           style: TextStyle(
-            color: ThemeProvider.theme.shadowColor,
+            color: ThemeProvider().isDarkMode? Colors.white54:ThemeProvider.theme.shadowColor,
           ),
         ),
         SizedBox(height: 5),

--- a/lib/Components/settings_text_field.dart
+++ b/lib/Components/settings_text_field.dart
@@ -29,7 +29,7 @@ class _SettingsTextFieldState extends State<SettingsTextField> {
         Text(
           widget.labelText,
           style: TextStyle(
-            color: ThemeProvider().isDarkMode? Colors.white54:ThemeProvider.theme.shadowColor,
+            color: ThemeProvider.theme.unselectedWidgetColor,
           ),
         ),
         SizedBox(height: 5),


### PR DESCRIPTION
Fixes #61 

Describe the changes you have made in this PR -

When user toggle to dark mode, the label in setting input field will be more visible (white54 instead of shadow black in dark mode. in light mode shadow black will be shown as before)

Screenshots of the changes (If any) -

Before:
![Simulator Screen Shot - iPhone 13 - 2022-02-01 at 12 14 04](https://user-images.githubusercontent.com/52542371/151927661-0c6a6b40-224e-448f-aa98-d1efe8be3ffa.png)

After:
![Simulator Screen Shot - iPhone 13 - 2022-02-01 at 12 47 31](https://user-images.githubusercontent.com/52542371/151927686-c8a2036f-2d72-464b-ac16-6077f9e66b49.png)

