### PR TITLE
Solves simple UI bug in add torrent screen

### DIFF
--- a/lib/Components/add_torrent_sheet.dart
+++ b/lib/Components/add_torrent_sheet.dart
@@ -44,7 +44,11 @@ class _AddTorrentSheetState extends State<AddTorrentSheet> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: ThemeProvider.theme.primaryColorLight,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.only(
+            topRight: Radius.circular(15), topLeft: Radius.circular(15)),
+        color: ThemeProvider.theme.primaryColorLight,
+      ),
       padding: EdgeInsets.symmetric(vertical: 25, horizontal: 20),
       child: Form(
         key: _formKey,


### PR DESCRIPTION
Fixes #71 

**Describe the changes you have made in this PR:**
- Made the container of the add torrent screen rounded to make the UI of the screen similar to the UI it has before the implementation of light/dark mode in the app.

**Screenshots of the changes:**
<table>
<tr>
<td align="center"><img src= "https://user-images.githubusercontent.com/73401649/153958310-42a042ef-a12f-4a9b-97cd-5e651ab413df.jpg" width="250"> <br /><b>Earlier screen before implementing the changes in this PR in dark mode</b></a><br /></td>
<td align="center"><img src= "https://user-images.githubusercontent.com/73401649/153958072-c83f086c-27ae-4276-a47b-aba8f393d3f7.jpg" width="250"><br /><b>Add torrent screen after implementing the changes made in this PR in dark mode</b></a><br /></td>
</tr>
</table>

<table>
<tr>
<td align="center"><img src= "https://user-images.githubusercontent.com/73401649/153958685-3583517f-ab8e-4a32-9227-485d781d5026.jpg" width="250"> <br /><b>Earlier screen before implementing the changes in this PR in light mode</b></a><br /></td>
<td align="center"><img src= "https://user-images.githubusercontent.com/73401649/153958527-0cb93b0d-c95c-4f95-a8aa-7e05955b2d78.jpg" width="250"><br /><b>Add torrent screen after implementing the changes made in this PR in light mode</b></a><br /></td>
</tr>
</table>
