### PR TITLE
fix: Resolves visibility issue in the LabelText of settings screen

### DIFF
--- a/lib/Components/settings_text_field.dart
+++ b/lib/Components/settings_text_field.dart
@@ -29,7 +29,7 @@ class _SettingsTextFieldState extends State<SettingsTextField> {
         Text(
           widget.labelText,
           style: TextStyle(
-            color: ThemeProvider.theme.shadowColor,
+            color: ThemeProvider.theme.textTheme.bodyText1?.color,
           ),
         ),
         SizedBox(height: 5),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -457,6 +457,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: "direct overridden"
     description:
@@ -755,7 +762,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
Fixes #79 

Describe the changes you have made in this PR -
Resolves visibility issue in the LabelText of different options of the settings screen in the dark mode of the app.

Screenshots of the changes (If any) -
<table>
<tr>
<td align="center"><img src= "https://user-images.githubusercontent.com/73401649/161582649-cb79fa71-45d2-4935-bf58-70e4f8eaaedc.jpg" width="250"> <br /><b>Earlier screen before implementing the changes in this PR</b></a><br /></td>
<td align="center"><img src= "https://user-images.githubusercontent.com/73401649/161582280-15429141-f8e7-44b8-95a2-f9cb0457cbfe.jpg" width="250"><br /><b>Screen after implementing the changes made in this PR</b></a><br /></td>
</tr>
</table>
