### PR TITLE
fix: Incompatible keyboard type for different TextFields of the settings option.

### DIFF
--- a/lib/Components/settings_text_field.dart
+++ b/lib/Components/settings_text_field.dart
@@ -39,7 +39,7 @@ class _SettingsTextFieldState extends State<SettingsTextField> {
             color: ThemeProvider.theme.textTheme.bodyText1?.color,
           ),
           keyboardType:
-              (!widget.isText) ? TextInputType.text : TextInputType.number,
+              (widget.isText) ? TextInputType.text : TextInputType.number,
           decoration: InputDecoration(
             floatingLabelBehavior: FloatingLabelBehavior.always,
             filled: true,


### PR DESCRIPTION
Fixes #83 

Describe the changes you have made in this PR -
Resolves incompatible keyboard type for different TextFields of the settings option.

Screenshots of the changes (If any) -

<table>
<tr>
<td align="center"><img src= "https://user-images.githubusercontent.com/73401649/161758725-6e71dd87-6c6a-431e-9793-a6c83f3e056c.jpg" width="250"> <br /><b>Incompatible Input keyboard (Screen-1)</b></a><br /></td>
<td align="center"><img src= "https://user-images.githubusercontent.com/73401649/161760289-bbf2e1de-ef3b-4343-80fa-8d8dd33a35cb.jpg" width="250"> <br /><b>Changed compatible Input keyboard (Screen-1)</b></a><br /></td>
<td align="center"><img src= "https://user-images.githubusercontent.com/73401649/161759057-d2d1d0e4-aef0-4ae3-babc-de9aa16b56ad.jpg" width="250"><br /><b>Incompatible Input keyboard (Screen-2)</b></a><br /></td>
<td align="center"><img src= "https://user-images.githubusercontent.com/73401649/161760425-f3dcae1d-596f-455b-a75f-02ce8e57d580.jpg" width="250"><br /><b>Changed compatible Input keyboard (Screen-2)</b></a><br /></td>
</tr>
</table>
