### PR TITLE
Add snackbar for adding feed and rule

### DIFF
--- a/lib/Components/RSSFeedHomePage.dart
+++ b/lib/Components/RSSFeedHomePage.dart
@@ -5,6 +5,7 @@ import 'package:flood_mobile/Api/update_feed_api.dart';
 import 'package:flood_mobile/Model/single_feed_and_response_model.dart';
 import 'package:flood_mobile/Provider/home_provider.dart';
 import 'package:flutter/material.dart';
+import 'package:flood_mobile/Components/flood_snackbar.dart';
 import 'package:provider/provider.dart';
 import '../Api/delete_feeds_and_rules.dart';
 import '../Api/feed_api.dart';
@@ -610,6 +611,13 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                                                     context: context,
                                                   );
                                                 }
+                                                final addFeedSnackbar = addFloodSnackBar(
+                                                    SnackbarType.information,
+                                                    'New Feed added successfully',
+                                                    'Dismiss');
+
+                                                ScaffoldMessenger.of(context)
+                                                    .showSnackBar(addFeedSnackbar);
                                                 FeedsApi.listAllFeedsAndRules(
                                                     context: context);
                                                 if (isUpdateFeedSelected) {
@@ -1984,6 +1992,13 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                                                   count: 0,
                                                   context: context,
                                                 );
+                                                final addRuleSnackbar = addFloodSnackBar(
+                                                    SnackbarType.information,
+                                                    'New Rule added successfully',
+                                                    'Dismiss');
+
+                                                ScaffoldMessenger.of(context)
+                                                    .showSnackBar(addRuleSnackbar);
                                                 FeedsApi.listAllFeedsAndRules(
                                                     context: context);
                                               });

--- a/lib/Components/RSSFeedHomePage.dart
+++ b/lib/Components/RSSFeedHomePage.dart
@@ -611,13 +611,16 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                                                     context: context,
                                                   );
                                                 }
-                                                final addFeedSnackbar = addFloodSnackBar(
-                                                    SnackbarType.information,
-                                                    'New Feed added successfully',
-                                                    'Dismiss');
+                                                final addFeedSnackbar =
+                                                    addFloodSnackBar(
+                                                        SnackbarType
+                                                            .information,
+                                                        'New Feed added successfully',
+                                                        'Dismiss');
 
                                                 ScaffoldMessenger.of(context)
-                                                    .showSnackBar(addFeedSnackbar);
+                                                    .showSnackBar(
+                                                        addFeedSnackbar);
                                                 FeedsApi.listAllFeedsAndRules(
                                                     context: context);
                                                 if (isUpdateFeedSelected) {
@@ -1992,13 +1995,16 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                                                   count: 0,
                                                   context: context,
                                                 );
-                                                final addRuleSnackbar = addFloodSnackBar(
-                                                    SnackbarType.information,
-                                                    'New Rule added successfully',
-                                                    'Dismiss');
+                                                final addRuleSnackbar =
+                                                    addFloodSnackBar(
+                                                        SnackbarType
+                                                            .information,
+                                                        'New Rule added successfully',
+                                                        'Dismiss');
 
                                                 ScaffoldMessenger.of(context)
-                                                    .showSnackBar(addRuleSnackbar);
+                                                    .showSnackBar(
+                                                        addRuleSnackbar);
                                                 FeedsApi.listAllFeedsAndRules(
                                                     context: context);
                                               });


### PR DESCRIPTION
Fixes #112 

Describe the changes you have made in this PR -

As mentioned in the issue, I have added snackbar when user adds a feed or a rule, to provide confirmation that it has been added successfully.

Screenshots of the changes (If any) -

![WhatsApp Image 2022-12-15 at 11 40 02](https://user-images.githubusercontent.com/37345795/207786016-846db8f0-39af-4c9a-b797-3d2bd0f7aa5e.jpg)

![WhatsApp Image 2022-12-15 at 11 39 54](https://user-images.githubusercontent.com/37345795/207786048-de985df0-d045-4329-8dc3-3d6ead20eeb3.jpg)


Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.
