### PR TITLE
Fix an issue of invalid number

### DIFF
--- a/lib/Api/event_handler_api.dart
+++ b/lib/Api/event_handler_api.dart
@@ -12,7 +12,7 @@ import 'package:provider/provider.dart';
 import '../Constants/notification_keys.dart';
 import '../Provider/filter_provider.dart';
 
-String torrentLength = '';
+String torrentLength = '0';
 
 class EventHandlerApi {
   //Sets the transfer rate if the event returned is TRANSFER_SUMMARY_FULL_UPDATE


### PR DESCRIPTION
Closes #121

`torrentLength` is being initialized to an empty string, which is causing a problem when we are passing it to `int.parse` as soon as the first torrent has been added. Initializing it to zero solves that problem.