### PR TITLE
Snackbar for add new user and add new torrent not working

### DIFF
--- a/lib/Components/bottom_floating_menu_button.dart
+++ b/lib/Components/bottom_floating_menu_button.dart
@@ -575,6 +575,14 @@ class _BottomFloatingMenuButtonState extends State<BottomFloatingMenuButton>
                                               isSequential: sequentialDownload,
                                               isCompleted: completed,
                                               context: context);
+                                          final addTorrentSnackbar =
+                                              addFloodSnackBar(
+                                                  SnackbarType.information,
+                                                  'Torrent added successfully',
+                                                  'Dismiss');
+
+                                          ScaffoldMessenger.of(context)
+                                              .showSnackBar(addTorrentSnackbar);
                                           Navigator.pop(context);
                                         },
                                         style: ElevatedButton.styleFrom(

--- a/lib/Components/bottom_floating_menu_button.dart
+++ b/lib/Components/bottom_floating_menu_button.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 import '../Api/torrent_api.dart';
 import '../Constants/theme_provider.dart';
 import '../Provider/client_provider.dart';
+import 'flood_snackbar.dart';
 
 class BottomFloatingMenuButton extends StatefulWidget {
   @override
@@ -301,6 +302,15 @@ class _BottomFloatingMenuButtonState extends State<BottomFloatingMenuButton>
                                                     sequentialDownload,
                                                 isCompleted: completed,
                                                 context: context);
+                                            final addTorrentSnackbar =
+                                                addFloodSnackBar(
+                                                    SnackbarType.information,
+                                                    'Torrent added successfully',
+                                                    'Dismiss');
+
+                                            ScaffoldMessenger.of(context)
+                                                .showSnackBar(
+                                                    addTorrentSnackbar);
                                             Navigator.pop(context);
                                           },
                                           style: ElevatedButton.styleFrom(

--- a/lib/Pages/settings_screen.dart
+++ b/lib/Pages/settings_screen.dart
@@ -763,7 +763,11 @@ class AuthenticationSection extends StatelessWidget {
                             level: isAdmin ? 10 : 5,
                             path: pathController.text,
                             host: hostController.text,
-                            port: int.parse(portController.text),
+                            port: int.parse(
+                              portController.text.isEmpty
+                                  ? "0"
+                                  : portController.text,
+                            ),
                           ),
                         );
                         final addNewUserSnackBar = addFloodSnackBar(


### PR DESCRIPTION
Fixes: #114 

1. Fixed a snackbar display when torrent was added through Bottom sheet using FAB
2. Fixed a snackbar display when user was added because the error was in Port number parsing.

Screenshots of the changes (If any) -
![156](https://user-images.githubusercontent.com/42129636/208474417-41b2766a-a27b-443d-9902-ac9176761164.gif)

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.
