### PR TITLE
Fix boundaries visibility on existings feeds and existing rules in light 

### DIFF
--- a/lib/Components/RSSFeedHomePage.dart
+++ b/lib/Components/RSSFeedHomePage.dart
@@ -1513,31 +1513,35 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                               key: Key('No rules defined'),
                               height: 60,
                               width: double.infinity,
-                              decoration: BoxDecoration(
-                                border: Border.all(color: Colors.white38),
-                                borderRadius: BorderRadius.only(
-                                  topRight: Radius.circular(8),
-                                  topLeft: Radius.circular(8),
-                                  bottomLeft: Radius.circular(8),
-                                  bottomRight: Radius.circular(8),
-                                ),
-                                color: ThemeProvider.theme.primaryColorLight,
-                              ),
-                              child: Row(
-                                mainAxisAlignment: MainAxisAlignment.start,
-                                children: [
-                                  Padding(
-                                    padding: const EdgeInsets.only(left: 10.0),
-                                    child: Text(
-                                      "No rules defined.",
-                                      style: TextStyle(
-                                          fontSize: 16,
-                                          fontFamily: 'Montserrat',
-                                          color: ThemeProvider.theme.textTheme
-                                              .bodyText1?.color),
+                              color: ThemeProvider.theme.primaryColorLight,
+                              child: InputDecorator(
+                                decoration: InputDecoration(
+                                  border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.only(
+                                      topRight: Radius.circular(8),
+                                      topLeft: Radius.circular(8),
+                                      bottomLeft: Radius.circular(8),
+                                      bottomRight: Radius.circular(8),
                                     ),
                                   ),
-                                ],
+                                ),
+                                child: Row(
+                                  mainAxisAlignment: MainAxisAlignment.start,
+                                  children: [
+                                    Padding(
+                                      padding:
+                                          const EdgeInsets.only(left: 10.0),
+                                      child: Text(
+                                        "No rules defined.",
+                                        style: TextStyle(
+                                            fontSize: 16,
+                                            fontFamily: 'Montserrat',
+                                            color: ThemeProvider.theme.textTheme
+                                                .bodyText1?.color),
+                                      ),
+                                    ),
+                                  ],
+                                ),
                               ),
                             ),
                       Padding(

--- a/lib/Components/RSSFeedHomePage.dart
+++ b/lib/Components/RSSFeedHomePage.dart
@@ -287,31 +287,35 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                                   Key('No existing feeds displaying container'),
                               height: 60,
                               width: double.infinity,
-                              decoration: BoxDecoration(
-                                border: Border.all(color: Colors.white38),
-                                borderRadius: BorderRadius.only(
-                                  topRight: Radius.circular(8),
-                                  topLeft: Radius.circular(8),
-                                  bottomLeft: Radius.circular(8),
-                                  bottomRight: Radius.circular(8),
-                                ),
-                                color: ThemeProvider.theme.primaryColorLight,
-                              ),
-                              child: Row(
-                                mainAxisAlignment: MainAxisAlignment.start,
-                                children: [
-                                  Padding(
-                                    padding: const EdgeInsets.only(left: 10.0),
-                                    child: Text(
-                                      "No feeds defined.",
-                                      style: TextStyle(
-                                          fontSize: 16,
-                                          fontFamily: 'Montserrat',
-                                          color: ThemeProvider.theme.textTheme
-                                              .bodyText1?.color),
+                              color: ThemeProvider.theme.primaryColorLight,
+                              child: InputDecorator(
+                                decoration: InputDecoration(
+                                  border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.only(
+                                      topRight: Radius.circular(8),
+                                      topLeft: Radius.circular(8),
+                                      bottomLeft: Radius.circular(8),
+                                      bottomRight: Radius.circular(8),
                                     ),
                                   ),
-                                ],
+                                ),
+                                child: Row(
+                                  mainAxisAlignment: MainAxisAlignment.start,
+                                  children: [
+                                    Padding(
+                                      padding:
+                                          const EdgeInsets.only(left: 10.0),
+                                      child: Text(
+                                        "No feeds defined.",
+                                        style: TextStyle(
+                                            fontSize: 16,
+                                            fontFamily: 'Montserrat',
+                                            color: ThemeProvider.theme.textTheme
+                                                .bodyText1?.color),
+                                      ),
+                                    ),
+                                  ],
+                                ),
                               ),
                             ),
                       Padding(


### PR DESCRIPTION
Fixes #131  Theme bug in rss-feed and download rules page in light mode.

Fix boundaries visibility on existings feeds and existing rules in light .

Screenshots of the changes : 
![Screenshot_1671912468 (1)](https://user-images.githubusercontent.com/91112485/209449827-b21ebd4c-a342-4933-bb9d-8d2b2e311a28.png)                   ![Screenshot_1671912470 (1)](https://user-images.githubusercontent.com/91112485/209449844-e65644bd-e599-4bfd-943a-dbaef2cbb436.png)



