### PR TITLE
Add snackbar on deleting a rss-feed/download rule.

### DIFF
--- a/lib/Components/RSSFeedHomePage.dart
+++ b/lib/Components/RSSFeedHomePage.dart
@@ -1458,6 +1458,17 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                                                     FeedsApi
                                                         .listAllFeedsAndRules(
                                                             context: context);
+                                                    final deleteRuleSnackbar =
+                                                        addFloodSnackBar(
+                                                            SnackbarType
+                                                                .information,
+                                                            'Rule deleted successfully',
+                                                            'Dismiss');
+                                                    ScaffoldMessenger.of(
+                                                            context)
+                                                        .showSnackBar(
+                                                      deleteRuleSnackbar,
+                                                    );
                                                   },
                                                 ),
                                               ],

--- a/lib/Components/RSSFeedHomePage.dart
+++ b/lib/Components/RSSFeedHomePage.dart
@@ -218,6 +218,17 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                                                     FeedsApi
                                                         .listAllFeedsAndRules(
                                                             context: context);
+                                                    final deleteFeedSnackbar =
+                                                        addFloodSnackBar(
+                                                            SnackbarType
+                                                                .information,
+                                                            'Feed deleted successfully',
+                                                            'Dismiss');
+                                                    ScaffoldMessenger.of(
+                                                            context)
+                                                        .showSnackBar(
+                                                      deleteFeedSnackbar,
+                                                    );
                                                   },
                                                 ),
                                               ],


### PR DESCRIPTION
Fixes #127 Add snackbar on deleting a rss-feed/download rule. 

Screenshots of the changes -

![Screenshot_1671956832 (Custom)](https://user-images.githubusercontent.com/91112485/209461592-66cc5eee-90ba-4b97-be35-55b151b57737.png)  ![Screenshot_1671956839 (Custom)](https://user-images.githubusercontent.com/91112485/209461594-9f737393-66a5-4e46-b183-354e21ddbf59.png)


