### PR TITLE
Add user accounts displaying section

### DIFF
--- a/lib/Api/auth_api.dart
+++ b/lib/Api/auth_api.dart
@@ -129,7 +129,9 @@ class AuthApi {
   static deleteUser(BuildContext context, String username) async {
     try {
       String url = Provider.of<ApiProvider>(context, listen: false).baseUrl +
-          ApiProvider.deleteUser + "/" + username;
+          ApiProvider.deleteUser +
+          "/" +
+          username;
       print('---DELETE USER---');
       print(url);
       Response response;

--- a/lib/Api/auth_api.dart
+++ b/lib/Api/auth_api.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:flood_mobile/Model/register_user_model.dart';
 import 'package:flood_mobile/Provider/user_detail_provider.dart';
+import 'package:flood_mobile/Model/current_user_detail_model.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -45,8 +46,9 @@ class AuthApi {
           // Setting token in shared preference
           SharedPreferences prefs = await SharedPreferences.getInstance();
           await prefs.setString('floodToken', token);
+          await prefs.setString('floodUsername', username);
           Provider.of<UserDetailProvider>(context, listen: false)
-              .setToken(token);
+              .setUserDetails(token, username);
           return true;
         }
         return false;
@@ -84,6 +86,68 @@ class AuthApi {
           .post(url, data: rawBody, queryParameters: {"cookie": false});
       print(response);
       if (response.statusCode == 200) {
+      } else {}
+    } catch (e) {
+      print('--ERROR--');
+      print(e.toString());
+    }
+  }
+
+  static getUsersList(BuildContext context) async {
+    try {
+      String url = Provider.of<ApiProvider>(context, listen: false).baseUrl +
+          ApiProvider.getUsersList;
+      print('---GET USERS LIST---');
+      print(url);
+      Response response;
+      Dio dio = new Dio();
+      //Headers
+      dio.options.headers['Accept'] = "application/json";
+      dio.options.headers['Content-Type'] = "application/json";
+      dio.options.headers['Connection'] = "keep-alive";
+      dio.options.headers['Cookie'] =
+          Provider.of<UserDetailProvider>(context, listen: false).token;
+      response = await dio.get(
+        url,
+      );
+      if (response.statusCode == 200) {
+        List<CurrentUserDetailModel> usersList = [];
+        for (final user in response.data) {
+          usersList.add(CurrentUserDetailModel.fromJson(user));
+        }
+        Provider.of<UserDetailProvider>(context, listen: false)
+            .setUsersList(usersList);
+        print('---USERS LIST---');
+        print(response);
+      } else {}
+    } catch (e) {
+      print('--ERROR--');
+      print(e.toString());
+    }
+  }
+
+  static deleteUser(BuildContext context, String username) async {
+    try {
+      String url = Provider.of<ApiProvider>(context, listen: false).baseUrl +
+          ApiProvider.deleteUser + "/" + username;
+      print('---DELETE USER---');
+      print(url);
+      Response response;
+      Dio dio = new Dio();
+      //Headers
+      dio.options.headers['Accept'] = "application/json";
+      dio.options.headers['Content-Type'] = "application/json";
+      dio.options.headers['Connection'] = "keep-alive";
+      dio.options.headers['Cookie'] =
+          Provider.of<UserDetailProvider>(context, listen: false).token;
+      response = await dio.delete(
+        url,
+      );
+      if (response.statusCode == 200) {
+        print(response);
+        print('---USER DELETED---');
+        // *Getting the users list again
+        getUsersList(context);
       } else {}
     } catch (e) {
       print('--ERROR--');

--- a/lib/Components/not_admin_label.dart
+++ b/lib/Components/not_admin_label.dart
@@ -1,0 +1,24 @@
+import 'package:flood_mobile/Constants/theme_provider.dart';
+import 'package:flutter/cupertino.dart';
+
+class NotAdminLabel extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: ThemeProvider.theme.errorColor,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: ThemeProvider.theme.primaryColor,
+          width: 1.0,
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Text("User is not Admin"),
+      ),
+    );
+  }
+
+}

--- a/lib/Components/not_admin_label.dart
+++ b/lib/Components/not_admin_label.dart
@@ -20,5 +20,4 @@ class NotAdminLabel extends StatelessWidget {
       ),
     );
   }
-
 }

--- a/lib/Components/users_list.dart
+++ b/lib/Components/users_list.dart
@@ -1,0 +1,29 @@
+import 'package:flood_mobile/Components/users_list_tile.dart';
+import 'package:flood_mobile/Model/current_user_detail_model.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class UsersListView extends StatelessWidget {
+  final List<CurrentUserDetailModel> usersList;
+  final String currentUsername;
+
+  const UsersListView({
+    Key? key,
+    required this.usersList,
+    required this.currentUsername,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      shrinkWrap: true,
+      itemCount: usersList.length,
+      itemBuilder: (context, index) {
+        return UsersListTile(
+          userModel: usersList[index],
+          isCurrent: usersList[index].username == currentUsername,
+        );
+      },
+    );
+  }
+}

--- a/lib/Components/users_list_tile.dart
+++ b/lib/Components/users_list_tile.dart
@@ -1,0 +1,75 @@
+import 'package:flood_mobile/Api/auth_api.dart';
+import 'package:flood_mobile/Model/current_user_detail_model.dart';
+import 'package:flood_mobile/Constants/theme_provider.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class UsersListTile extends StatelessWidget {
+  final CurrentUserDetailModel userModel;
+  final bool isCurrent;
+
+  const UsersListTile({
+    Key? key,
+    required this.userModel,
+    required this.isCurrent,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 50.0,
+      padding: EdgeInsets.symmetric(vertical: 5),
+      decoration: BoxDecoration(
+        color: ThemeProvider.theme.primaryColorLight,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: ThemeProvider.theme.primaryColor,
+          width: 1.0,
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Row(
+          children: [
+            Text(
+              userModel.username,
+              style: TextStyle(
+                color: ThemeProvider.theme.textTheme.bodyText1?.color,
+              ),
+            ),
+            Spacer(),
+            (isCurrent)
+                ? Container(
+                    decoration: BoxDecoration(
+                      color: ThemeProvider.theme.highlightColor,
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 6.0,
+                        vertical: 4.0,
+                      ),
+                      child: Text('Current User'),
+                    ),
+                  )
+                : Center(
+                    child: IconButton(
+                      padding: EdgeInsets.zero,
+                      onPressed: () {
+                        AuthApi.deleteUser(context, userModel.username);
+                      },
+                      icon: Icon(
+                        Icons.close,
+                        size: 20.0,
+                      ),
+                    ),
+                  ),
+            SizedBox(
+              width: 8.0,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/Constants/theme_provider.dart
+++ b/lib/Constants/theme_provider.dart
@@ -26,6 +26,8 @@ class MyThemes {
     primaryColorLight: Color(0xff305067),
     accentColor: Color(0xff399CF4),
     backgroundColor: Color(0xff305067),
+    highlightColor: Color(0xff415062),
+    errorColor: Color(0xffF34570),
     scaffoldBackgroundColor: Color(0xff305067),
     textTheme: TextTheme().apply(
       displayColor: Colors.white,
@@ -44,6 +46,8 @@ class MyThemes {
     primaryColor: Colors.white,
     primaryColorDark: Color(0xff39C481),
     backgroundColor: Color(0xff293341),
+    highlightColor: Color(0xff415062),
+    errorColor: Color(0xffF34570),
     scaffoldBackgroundColor: Colors.grey[300],
     accentColor: Color(0xff399CF4),
     canvasColor: Colors.transparent,

--- a/lib/Pages/home_screen.dart
+++ b/lib/Pages/home_screen.dart
@@ -29,8 +29,10 @@ import 'package:uni_links/uni_links.dart';
 import 'package:uri_to_file/uri_to_file.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:flood_mobile/Components/change_theme_button_widget.dart';
+import '../Api/auth_api.dart';
 import '../Api/torrent_api.dart';
 import '../Constants/notification_keys.dart';
+import '../Model/current_user_detail_model.dart';
 import '../Provider/api_provider.dart';
 import '../Components/RSSFeedButtonWidget.dart';
 
@@ -61,6 +63,7 @@ class _HomeScreenState extends State<HomeScreen> {
     //Initialize the ap
     Provider.of<SSEProvider>(context, listen: false).listenToSSE(context);
     ClientApi.getClientSettings(context);
+    AuthApi.getUsersList(context);
     NotificationApi.getNotifications(context: context);
     super.didChangeDependencies();
   }
@@ -326,8 +329,11 @@ class _MenuState extends State<Menu> {
                       SharedPreferences prefs =
                           await SharedPreferences.getInstance();
                       prefs.setString('floodToken', '');
+                      prefs.setString('floodUsername', '');
                       Provider.of<UserDetailProvider>(context, listen: false)
-                          .setToken('');
+                          .setUserDetails('', '');
+                      Provider.of<UserDetailProvider>(context, listen: false)
+                          .setUsersList(<CurrentUserDetailModel>[]);
                       Navigator.of(context).pushNamedAndRemoveUntil(
                           Routes.loginScreenRoute,
                           (Route<dynamic> route) => false);

--- a/lib/Pages/splash_screen.dart
+++ b/lib/Pages/splash_screen.dart
@@ -28,19 +28,26 @@ class _SplashScreenState extends State<SplashScreen> {
     String token = prefs.getString('floodToken') ?? '';
     print('Token: ' + token);
     String baseUrl = prefs.getString('baseUrl') ?? '';
-    if (token != '' && baseUrl != '' && loggedInBefore == true) {
-      Provider.of<UserDetailProvider>(context, listen: false).setToken(token);
+    String username = prefs.getString('floodUsername') ?? '';
+    if (token != '' &&
+        baseUrl != '' &&
+        username != '' &&
+        loggedInBefore == true) {
+      Provider.of<UserDetailProvider>(context, listen: false).setUserDetails(
+        token,
+        username,
+      );
       Provider.of<ApiProvider>(context, listen: false).setBaseUrl(baseUrl);
       Navigator.of(context).pushNamedAndRemoveUntil(
           Routes.homeScreenRoute, (Route<dynamic> route) => false);
     }
-    if (token == '' && baseUrl == '' && loggedInBefore == false) {
+    if (token == '' && baseUrl == '' && username == '' && loggedInBefore == false) {
       Provider.of<LoginStatusDataProvider>(context, listen: false)
           .setLoggedInStatus(true);
       Navigator.of(context)
           .push(MaterialPageRoute(builder: (context) => OnboardingMainPage()));
     }
-    if (token == '' && baseUrl == '' && loggedInBefore == true) {
+    if (token == '' && baseUrl == '' && username == '' && loggedInBefore == true) {
       Navigator.of(context).pushNamedAndRemoveUntil(
           Routes.loginScreenRoute, (Route<dynamic> route) => false);
     }

--- a/lib/Pages/splash_screen.dart
+++ b/lib/Pages/splash_screen.dart
@@ -41,13 +41,19 @@ class _SplashScreenState extends State<SplashScreen> {
       Navigator.of(context).pushNamedAndRemoveUntil(
           Routes.homeScreenRoute, (Route<dynamic> route) => false);
     }
-    if (token == '' && baseUrl == '' && username == '' && loggedInBefore == false) {
+    if (token == '' &&
+        baseUrl == '' &&
+        username == '' &&
+        loggedInBefore == false) {
       Provider.of<LoginStatusDataProvider>(context, listen: false)
           .setLoggedInStatus(true);
       Navigator.of(context)
           .push(MaterialPageRoute(builder: (context) => OnboardingMainPage()));
     }
-    if (token == '' && baseUrl == '' && username == '' && loggedInBefore == true) {
+    if (token == '' &&
+        baseUrl == '' &&
+        username == '' &&
+        loggedInBefore == true) {
       Navigator.of(context).pushNamedAndRemoveUntil(
           Routes.loginScreenRoute, (Route<dynamic> route) => false);
     }

--- a/lib/Provider/api_provider.dart
+++ b/lib/Provider/api_provider.dart
@@ -4,8 +4,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 class ApiProvider extends ChangeNotifier {
   String baseUrl = 'http://localhost:3000';
   static String authenticateUrl = '/api/auth/authenticate';
-  static String getCurrentUserDetails = '/api/auth/users';
+  static String getUsersList = '/api/auth/users';
   static String registerUser = '/api/auth/register';
+  static String deleteUser = '/api/auth/users';
   static String startTorrentUrl = '/api/torrents/start';
   static String getTorrentListUrl = '/api/torrents';
   static String stopTorrentUrl = '/api/torrents/stop';

--- a/lib/Provider/user_detail_provider.dart
+++ b/lib/Provider/user_detail_provider.dart
@@ -1,9 +1,19 @@
+import 'package:flood_mobile/Model/current_user_detail_model.dart';
 import 'package:flutter/cupertino.dart';
 
 class UserDetailProvider extends ChangeNotifier {
   String token = '';
-  void setToken(String newToken) {
+  String username = '';
+  late List<CurrentUserDetailModel> usersList = [];
+
+  void setUserDetails(String newToken, String newUsername) {
     token = newToken;
+    username = newUsername;
+    notifyListeners();
+  }
+
+  void setUsersList(newUsersList) {
+    usersList = newUsersList;
     notifyListeners();
   }
 }

--- a/test/user_detail_provider_unit_test.dart
+++ b/test/user_detail_provider_unit_test.dart
@@ -12,19 +12,24 @@ void main() {
     "initial values are correct",
     () {
       expect(sut.token, '');
+      expect(sut.username, '');
     },
   );
 
   group('setToken', () {
     final newToken = 'test token';
+    final newUsername = 'testUsername';
 
     test(
-      "tests setToken working",
+      "tests setUsersDetails working",
       () async {
         expect(sut.token.isEmpty, true);
-        sut.setToken(newToken);
+        expect(sut.username.isEmpty, true);
+        sut.setUserDetails(newToken, newUsername);
         expect(sut.token.isEmpty, false);
+        expect(sut.username.isEmpty, false);
         expect(sut.token, 'test token');
+        expect(sut.username, 'testUsername');
       },
     );
   });


### PR DESCRIPTION
Closes #129 

Tasks achieved in this PR -

1. **Display the list of users**: Wrote a function `getUsersList` in `AuthApi` to find the list of users (Refer the attached picture).
2. **Add username to SharedPreferences**: Because I could not find any way to find the current user via API, I added the current username to `SharedPreferences` along with token, which gets destroyed after the user has logged out.
3. **Delete a user**: If the current user is an admin, they will be able to delete any of the other users with a single tap. Wrote a function `deleteUser` in `AuthApi` which handles the API.
4. **Restrict non admin users from updating Authentication settings**: I check on Flood web app, if the user is not an admin, they are not able to change any of the settings under Authentication head, but this was not the case in the mobile app. So, I have handled the case when user is not an admin (Refer the attached picture).
5. **Update tests for UserDetailsProvider**: Because now `username` is also getting stored in `SharedPreferences` along with `token`, thus made the necessary changes in `user_detail_provider_unit_test.dart` to cover that portion too.

Screenshots of the changes -

**User Accounts List -**

<img height="500px" src="https://user-images.githubusercontent.com/37345795/209470864-1eca82ee-885e-47ab-9d82-e0bbddf8aedb.jpg" >

**Not Admin -**

<img height="500px" src="https://user-images.githubusercontent.com/37345795/209470906-438426b0-bdf3-4cba-9ef2-66bc3769dd09.jpg" >

**Ref of web app, when user is not admin -**

<img height="500px" src="https://user-images.githubusercontent.com/37345795/209470928-3a26495a-8b41-460e-93c2-56fc26d5c835.png" >