### PR TITLE
fix text overflow in rss feed and torrent details

### DIFF
--- a/lib/Components/RSSFeedHomePage.dart
+++ b/lib/Components/RSSFeedHomePage.dart
@@ -152,9 +152,11 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                                             Expanded(
                                               child: Row(
                                                 children: [
-                                                  Text(model
-                                                      .RssFeedsList[index].label
-                                                      .toString()),
+                                                  Flexible(
+                                                    child: Text(model
+                                                        .RssFeedsList[index].label
+                                                        .toString()),
+                                                  ),
                                                   SizedBox(width: 10),
                                                   Text(model.RssFeedsList[index]
                                                               .count !=
@@ -1318,9 +1320,11 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                                             Expanded(
                                               child: Row(
                                                 children: [
-                                                  Text(model
-                                                      .RssRulesList[index].label
-                                                      .toString()),
+                                                  Flexible(
+                                                    child: Text(model
+                                                        .RssRulesList[index].label
+                                                        .toString()),
+                                                  ),
                                                   SizedBox(width: 10),
                                                   Text(model.RssRulesList[index]
                                                               .count !=

--- a/lib/Components/RSSFeedHomePage.dart
+++ b/lib/Components/RSSFeedHomePage.dart
@@ -154,7 +154,8 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                                                 children: [
                                                   Flexible(
                                                     child: Text(model
-                                                        .RssFeedsList[index].label
+                                                        .RssFeedsList[index]
+                                                        .label
                                                         .toString()),
                                                   ),
                                                   SizedBox(width: 10),
@@ -1322,7 +1323,8 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                                                 children: [
                                                   Flexible(
                                                     child: Text(model
-                                                        .RssRulesList[index].label
+                                                        .RssRulesList[index]
+                                                        .label
                                                         .toString()),
                                                   ),
                                                   SizedBox(width: 10),

--- a/lib/Components/torrent_tile.dart
+++ b/lib/Components/torrent_tile.dart
@@ -49,6 +49,7 @@ class _TorrentTileState extends State<TorrentTile> {
   @override
   Widget build(BuildContext context) {
     double hp = MediaQuery.of(context).size.height;
+    double wp = MediaQuery.of(context).size.width;
     return Slidable(
       actionPane: SlidableBehindActionPane(),
       actionExtentRatio: 0.25,
@@ -315,7 +316,12 @@ class _TorrentTileState extends State<TorrentTile> {
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
                           Text('Location'),
-                          Text(widget.model.directory),
+                          Flexible(
+                            child: Container(
+                              padding: EdgeInsets.only(left: wp * 0.1),
+                              child: Text(widget.model.directory),
+                            ),
+                          ),
                         ],
                       ),
                       SizedBox(
@@ -327,9 +333,14 @@ class _TorrentTileState extends State<TorrentTile> {
                           Text(
                             'Tags',
                           ),
-                          Text((widget.model.tags.length != 0)
-                              ? widget.model.tags.toString()
-                              : 'None'),
+                          Flexible(
+                            child: Container(
+                              padding: EdgeInsets.only(left: wp * 0.17),
+                              child: Text((widget.model.tags.length != 0)
+                                  ? widget.model.tags.toString()
+                                  : 'None'),
+                            ),
+                          ),
                         ],
                       ),
                       SizedBox(


### PR DESCRIPTION
fix followings text overflow issues in rss feed and torrent details page

![Location_space (Custom)](https://user-images.githubusercontent.com/91112485/211142503-6bc53ed6-e79b-4d29-80db-3b55351e54bd.png) ![Screenshot_1673026672 (Custom)](https://user-images.githubusercontent.com/91112485/211142504-e3a8fa77-6fcb-498d-b1b8-b523a3d21191.png)
![download lable issue (Custom)](https://user-images.githubusercontent.com/91112485/211142506-6a2828f4-5758-4605-bac7-759463e82c1d.png)  ![feeds rules overflow issue (Custom)](https://user-images.githubusercontent.com/91112485/211142507-d30462f4-75c6-4ff7-a8c1-4f722cf1bb84.png)

Screenshots of the changes  -

![Location_space_solution1 (2) (Custom)](https://user-images.githubusercontent.com/91112485/211142586-873c7ea9-ecf1-4036-98a7-c13e8e225ea9.png)  ![Screenshot_1673082267 (Custom)](https://user-images.githubusercontent.com/91112485/211142772-804f1cc7-a8fd-4e23-8561-ca4d9f79cc1c.png)
![feeds rules overflow solution (Custom)](https://user-images.githubusercontent.com/91112485/211142587-ff2c3412-a4a0-440a-b1ec-95178d416d15.png)  ![download lable issue solution (Custom)](https://user-images.githubusercontent.com/91112485/211142589-662ed35e-52e4-4e60-9035-ae94dd0e8d3f.png)


