### PR TITLE
add multiple formate video and audio in video stream screen

### DIFF
--- a/lib/Components/torrent_content_tile.dart
+++ b/lib/Components/torrent_content_tile.dart
@@ -130,7 +130,12 @@ class _TorrentFileTileState extends State<TorrentFileTile> {
           },
           onTap: () {
             String fileType = widget.model.filename.split('.').last;
-            if (fileType == 'mp4') {
+            if (fileType == 'mp4' ||
+                fileType == 'mkv' ||
+                fileType == 'webm' ||
+                fileType == 'mov' ||
+                fileType == 'mp3' ||
+                fileType == 'wav') {
               Navigator.of(context).pushNamed(
                 Routes.streamVideoScreenRoute,
                 arguments: VideoStreamScreenArguments(

--- a/lib/Model/torrent_content_model.dart
+++ b/lib/Model/torrent_content_model.dart
@@ -32,7 +32,11 @@ class TorrentContentModel {
       depth: json['path'].split('/').length,
       parentPath: json['path'].split('/'),
       isMediaFile: (json['filename'].split('.').last == 'mp3' ||
-          json['filename'].split('.').last == 'mp4'),
+          json['filename'].split('.').last == 'wav' ||
+          json['filename'].split('.').last == 'mp4' ||
+          json['filename'].split('.').last == 'mkv' ||
+          json['filename'].split('.').last == 'mov' ||
+          json['filename'].split('.').last == 'webm'),
     );
   }
 }


### PR DESCRIPTION
Add multiple formate video and audio in video stream screen

In video stream screen only MP4 video extention is supported. I added mp3, wav, mkv, mov, webm files for play video.
