### PR TITLE
- fix: make checkbox clearly visible onClick

### DIFF
--- a/lib/Components/bottom_floating_menu_button.dart
+++ b/lib/Components/bottom_floating_menu_button.dart
@@ -220,65 +220,78 @@ class _BottomFloatingMenuButtonState extends State<BottomFloatingMenuButton>
                                       SizedBox(
                                         height: 20,
                                       ),
-                                      CheckboxListTile(
-                                        activeColor: ThemeProvider
-                                            .theme.primaryColorDark,
-                                        tileColor: ThemeProvider
-                                            .theme.primaryColorLight,
-                                        shape: RoundedRectangleBorder(
-                                          borderRadius:
-                                              BorderRadius.circular(8),
+                                      StatefulBuilder(
+                                        builder: (BuildContext context,
+                                                StateSetter _setState) =>
+                                            CheckboxListTile(
+                                          activeColor: ThemeProvider
+                                              .theme.primaryColorDark,
+                                          tileColor: ThemeProvider
+                                              .theme.primaryColorLight,
+                                          shape: RoundedRectangleBorder(
+                                            borderRadius:
+                                                BorderRadius.circular(8),
+                                          ),
+                                          title: Text(
+                                            'Use as Base Path',
+                                            style: TextStyle(fontSize: 14),
+                                          ),
+                                          value: useAdBasePath,
+                                          onChanged: (bool? value) {
+                                            _setState(() {
+                                              useAdBasePath = value ?? false;
+                                            });
+                                          },
                                         ),
-                                        title: Text(
-                                          'Use as Base Path',
-                                          style: TextStyle(fontSize: 14),
-                                        ),
-                                        value: useAdBasePath,
-                                        onChanged: (bool? value) {
-                                          setState(() {
-                                            useAdBasePath = value ?? false;
-                                          });
-                                        },
                                       ),
-                                      CheckboxListTile(
-                                        activeColor: ThemeProvider
-                                            .theme.primaryColorDark,
-                                        tileColor: ThemeProvider
-                                            .theme.primaryColorLight,
-                                        shape: RoundedRectangleBorder(
-                                          borderRadius:
-                                              BorderRadius.circular(8),
+                                      StatefulBuilder(
+                                        builder: (BuildContext context,
+                                                StateSetter _setState) =>
+                                            CheckboxListTile(
+                                          activeColor: ThemeProvider
+                                              .theme.primaryColorDark,
+                                          tileColor: ThemeProvider
+                                              .theme.primaryColorLight,
+                                          shape: RoundedRectangleBorder(
+                                            borderRadius:
+                                                BorderRadius.circular(8),
+                                          ),
+                                          title: Text(
+                                            'Sequential Download',
+                                            style: TextStyle(fontSize: 14),
+                                          ),
+                                          value: sequentialDownload,
+                                          onChanged: (bool? value) {
+                                            _setState(() {
+                                              sequentialDownload =
+                                                  value ?? false;
+                                            });
+                                          },
                                         ),
-                                        title: Text(
-                                          'Sequential Download',
-                                          style: TextStyle(fontSize: 14),
-                                        ),
-                                        value: sequentialDownload,
-                                        onChanged: (bool? value) {
-                                          setState(() {
-                                            sequentialDownload = value ?? false;
-                                          });
-                                        },
                                       ),
-                                      CheckboxListTile(
-                                        activeColor: ThemeProvider
-                                            .theme.primaryColorDark,
-                                        tileColor: ThemeProvider
-                                            .theme.primaryColorLight,
-                                        shape: RoundedRectangleBorder(
-                                          borderRadius:
-                                              BorderRadius.circular(8),
+                                      StatefulBuilder(
+                                        builder: (BuildContext context,
+                                                StateSetter _setState) =>
+                                            CheckboxListTile(
+                                          activeColor: ThemeProvider
+                                              .theme.primaryColorDark,
+                                          tileColor: ThemeProvider
+                                              .theme.primaryColorLight,
+                                          shape: RoundedRectangleBorder(
+                                            borderRadius:
+                                                BorderRadius.circular(8),
+                                          ),
+                                          title: Text(
+                                            'Completed',
+                                            style: TextStyle(fontSize: 14),
+                                          ),
+                                          value: completed,
+                                          onChanged: (bool? value) {
+                                            _setState(() {
+                                              completed = value ?? false;
+                                            });
+                                          },
                                         ),
-                                        title: Text(
-                                          'Completed',
-                                          style: TextStyle(fontSize: 14),
-                                        ),
-                                        value: completed,
-                                        onChanged: (bool? value) {
-                                          setState(() {
-                                            completed = value ?? false;
-                                          });
-                                        },
                                       ),
                                       SizedBox(
                                         height: 15,
@@ -496,62 +509,77 @@ class _BottomFloatingMenuButtonState extends State<BottomFloatingMenuButton>
                                     SizedBox(
                                       height: 20,
                                     ),
-                                    CheckboxListTile(
-                                      activeColor:
-                                          ThemeProvider.theme.primaryColorDark,
-                                      tileColor:
-                                          ThemeProvider.theme.primaryColorLight,
-                                      shape: RoundedRectangleBorder(
-                                        borderRadius: BorderRadius.circular(8),
+                                    StatefulBuilder(
+                                      builder: (BuildContext context,
+                                              StateSetter _setState) =>
+                                          CheckboxListTile(
+                                        activeColor: ThemeProvider
+                                            .theme.primaryColorDark,
+                                        tileColor: ThemeProvider
+                                            .theme.primaryColorLight,
+                                        shape: RoundedRectangleBorder(
+                                          borderRadius:
+                                              BorderRadius.circular(8),
+                                        ),
+                                        title: Text(
+                                          'Use as Base Path',
+                                          style: TextStyle(fontSize: 14),
+                                        ),
+                                        value: useAdBasePath,
+                                        onChanged: (bool? value) {
+                                          _setState(() {
+                                            useAdBasePath = value ?? false;
+                                          });
+                                        },
                                       ),
-                                      title: Text(
-                                        'Use as Base Path',
-                                        style: TextStyle(fontSize: 14),
-                                      ),
-                                      value: useAdBasePath,
-                                      onChanged: (bool? value) {
-                                        setState(() {
-                                          useAdBasePath = value ?? false;
-                                        });
-                                      },
                                     ),
-                                    CheckboxListTile(
-                                      activeColor:
-                                          ThemeProvider.theme.primaryColorDark,
-                                      tileColor:
-                                          ThemeProvider.theme.primaryColorLight,
-                                      shape: RoundedRectangleBorder(
-                                        borderRadius: BorderRadius.circular(8),
+                                    StatefulBuilder(
+                                      builder: (BuildContext context,
+                                              StateSetter _setState) =>
+                                          CheckboxListTile(
+                                        activeColor: ThemeProvider
+                                            .theme.primaryColorDark,
+                                        tileColor: ThemeProvider
+                                            .theme.primaryColorLight,
+                                        shape: RoundedRectangleBorder(
+                                          borderRadius:
+                                              BorderRadius.circular(8),
+                                        ),
+                                        title: Text(
+                                          'Sequential Download',
+                                          style: TextStyle(fontSize: 14),
+                                        ),
+                                        value: sequentialDownload,
+                                        onChanged: (bool? value) {
+                                          _setState(() {
+                                            sequentialDownload = value ?? false;
+                                          });
+                                        },
                                       ),
-                                      title: Text(
-                                        'Sequential Download',
-                                        style: TextStyle(fontSize: 14),
-                                      ),
-                                      value: sequentialDownload,
-                                      onChanged: (bool? value) {
-                                        setState(() {
-                                          sequentialDownload = value ?? false;
-                                        });
-                                      },
                                     ),
-                                    CheckboxListTile(
-                                      activeColor:
-                                          ThemeProvider.theme.primaryColorDark,
-                                      tileColor:
-                                          ThemeProvider.theme.primaryColorLight,
-                                      shape: RoundedRectangleBorder(
-                                        borderRadius: BorderRadius.circular(8),
+                                    StatefulBuilder(
+                                      builder: (BuildContext context,
+                                              StateSetter _setState) =>
+                                          CheckboxListTile(
+                                        activeColor: ThemeProvider
+                                            .theme.primaryColorDark,
+                                        tileColor: ThemeProvider
+                                            .theme.primaryColorLight,
+                                        shape: RoundedRectangleBorder(
+                                          borderRadius:
+                                              BorderRadius.circular(8),
+                                        ),
+                                        title: Text(
+                                          'Completed',
+                                          style: TextStyle(fontSize: 14),
+                                        ),
+                                        value: completed,
+                                        onChanged: (bool? value) {
+                                          _setState(() {
+                                            completed = value ?? false;
+                                          });
+                                        },
                                       ),
-                                      title: Text(
-                                        'Completed',
-                                        style: TextStyle(fontSize: 14),
-                                      ),
-                                      value: completed,
-                                      onChanged: (bool? value) {
-                                        setState(() {
-                                          completed = value ?? false;
-                                        });
-                                      },
                                     ),
                                     SizedBox(
                                       height: 15,

--- a/packages/flutter_client_sse/pubspec.lock
+++ b/packages/flutter_client_sse/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.1"
   charcode:
     dependency: transitive
     description:
@@ -35,21 +35,21 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,21 +80,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.12"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   pedantic:
     dependency: transitive
     description:
@@ -113,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -134,21 +141,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:
@@ -162,7 +169,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "50.0.0"
+    version: "38.0.0"
   analyzer:
     dependency: "direct overridden"
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.0"
+    version: "3.4.1"
   args:
     dependency: transitive
     description:
@@ -680,21 +680,7 @@ packages:
       name: permission_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "10.2.0"
-  permission_handler_android:
-    dependency: transitive
-    description:
-      name: permission_handler_android
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "10.2.0"
-  permission_handler_apple:
-    dependency: transitive
-    description:
-      name: permission_handler_apple
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "9.0.7"
+    version: "8.3.0"
   permission_handler_platform_interface:
     dependency: transitive
     description:
@@ -702,13 +688,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.9.0"
-  permission_handler_windows:
-    dependency: transitive
-    description:
-      name: permission_handler_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.2"
   petitparser:
     dependency: transitive
     description:


### PR DESCRIPTION

# Fixes #128 

- Describe the changes you have made in this PR :
Since the checkboxlisttile was in a bottomSheet it wasnt working as expected, now all checkboxlisttiles are wrapped with statefulbuilder which will listen to checkbox onclick even and repaints only the checkBox instead of whole sheet.


# Screenshots of the changes 

https://user-images.githubusercontent.com/93595710/212462379-5351b4d9-0898-41a3-9b3f-01b385c88b95.mp4

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.
