### PR TITLE
fix: make checkbox clearly visible onclick

### DIFF
--- a/lib/Components/bottom_floating_menu_button.dart
+++ b/lib/Components/bottom_floating_menu_button.dart
@@ -220,65 +220,78 @@ class _BottomFloatingMenuButtonState extends State<BottomFloatingMenuButton>
                                       SizedBox(
                                         height: 20,
                                       ),
-                                      CheckboxListTile(
-                                        activeColor: ThemeProvider
-                                            .theme.primaryColorDark,
-                                        tileColor: ThemeProvider
-                                            .theme.primaryColorLight,
-                                        shape: RoundedRectangleBorder(
-                                          borderRadius:
-                                              BorderRadius.circular(8),
+                                      StatefulBuilder(
+                                        builder: (BuildContext context,
+                                                StateSetter _setState) =>
+                                            CheckboxListTile(
+                                          activeColor: ThemeProvider
+                                              .theme.primaryColorDark,
+                                          tileColor: ThemeProvider
+                                              .theme.primaryColorLight,
+                                          shape: RoundedRectangleBorder(
+                                            borderRadius:
+                                                BorderRadius.circular(8),
+                                          ),
+                                          title: Text(
+                                            'Use as Base Path',
+                                            style: TextStyle(fontSize: 14),
+                                          ),
+                                          value: useAdBasePath,
+                                          onChanged: (bool? value) {
+                                            _setState(() {
+                                              useAdBasePath = value ?? false;
+                                            });
+                                          },
                                         ),
-                                        title: Text(
-                                          'Use as Base Path',
-                                          style: TextStyle(fontSize: 14),
-                                        ),
-                                        value: useAdBasePath,
-                                        onChanged: (bool? value) {
-                                          setState(() {
-                                            useAdBasePath = value ?? false;
-                                          });
-                                        },
                                       ),
-                                      CheckboxListTile(
-                                        activeColor: ThemeProvider
-                                            .theme.primaryColorDark,
-                                        tileColor: ThemeProvider
-                                            .theme.primaryColorLight,
-                                        shape: RoundedRectangleBorder(
-                                          borderRadius:
-                                              BorderRadius.circular(8),
+                                      StatefulBuilder(
+                                        builder: (BuildContext context,
+                                                StateSetter _setState) =>
+                                            CheckboxListTile(
+                                          activeColor: ThemeProvider
+                                              .theme.primaryColorDark,
+                                          tileColor: ThemeProvider
+                                              .theme.primaryColorLight,
+                                          shape: RoundedRectangleBorder(
+                                            borderRadius:
+                                                BorderRadius.circular(8),
+                                          ),
+                                          title: Text(
+                                            'Sequential Download',
+                                            style: TextStyle(fontSize: 14),
+                                          ),
+                                          value: sequentialDownload,
+                                          onChanged: (bool? value) {
+                                            _setState(() {
+                                              sequentialDownload =
+                                                  value ?? false;
+                                            });
+                                          },
                                         ),
-                                        title: Text(
-                                          'Sequential Download',
-                                          style: TextStyle(fontSize: 14),
-                                        ),
-                                        value: sequentialDownload,
-                                        onChanged: (bool? value) {
-                                          setState(() {
-                                            sequentialDownload = value ?? false;
-                                          });
-                                        },
                                       ),
-                                      CheckboxListTile(
-                                        activeColor: ThemeProvider
-                                            .theme.primaryColorDark,
-                                        tileColor: ThemeProvider
-                                            .theme.primaryColorLight,
-                                        shape: RoundedRectangleBorder(
-                                          borderRadius:
-                                              BorderRadius.circular(8),
+                                      StatefulBuilder(
+                                        builder: (BuildContext context,
+                                                StateSetter _setState) =>
+                                            CheckboxListTile(
+                                          activeColor: ThemeProvider
+                                              .theme.primaryColorDark,
+                                          tileColor: ThemeProvider
+                                              .theme.primaryColorLight,
+                                          shape: RoundedRectangleBorder(
+                                            borderRadius:
+                                                BorderRadius.circular(8),
+                                          ),
+                                          title: Text(
+                                            'Completed',
+                                            style: TextStyle(fontSize: 14),
+                                          ),
+                                          value: completed,
+                                          onChanged: (bool? value) {
+                                            _setState(() {
+                                              completed = value ?? false;
+                                            });
+                                          },
                                         ),
-                                        title: Text(
-                                          'Completed',
-                                          style: TextStyle(fontSize: 14),
-                                        ),
-                                        value: completed,
-                                        onChanged: (bool? value) {
-                                          setState(() {
-                                            completed = value ?? false;
-                                          });
-                                        },
                                       ),
                                       SizedBox(
                                         height: 15,
@@ -496,62 +509,77 @@ class _BottomFloatingMenuButtonState extends State<BottomFloatingMenuButton>
                                     SizedBox(
                                       height: 20,
                                     ),
-                                    CheckboxListTile(
-                                      activeColor:
-                                          ThemeProvider.theme.primaryColorDark,
-                                      tileColor:
-                                          ThemeProvider.theme.primaryColorLight,
-                                      shape: RoundedRectangleBorder(
-                                        borderRadius: BorderRadius.circular(8),
+                                    StatefulBuilder(
+                                      builder: (BuildContext context,
+                                              StateSetter _setState) =>
+                                          CheckboxListTile(
+                                        activeColor: ThemeProvider
+                                            .theme.primaryColorDark,
+                                        tileColor: ThemeProvider
+                                            .theme.primaryColorLight,
+                                        shape: RoundedRectangleBorder(
+                                          borderRadius:
+                                              BorderRadius.circular(8),
+                                        ),
+                                        title: Text(
+                                          'Use as Base Path',
+                                          style: TextStyle(fontSize: 14),
+                                        ),
+                                        value: useAdBasePath,
+                                        onChanged: (bool? value) {
+                                          _setState(() {
+                                            useAdBasePath = value ?? false;
+                                          });
+                                        },
                                       ),
-                                      title: Text(
-                                        'Use as Base Path',
-                                        style: TextStyle(fontSize: 14),
-                                      ),
-                                      value: useAdBasePath,
-                                      onChanged: (bool? value) {
-                                        setState(() {
-                                          useAdBasePath = value ?? false;
-                                        });
-                                      },
                                     ),
-                                    CheckboxListTile(
-                                      activeColor:
-                                          ThemeProvider.theme.primaryColorDark,
-                                      tileColor:
-                                          ThemeProvider.theme.primaryColorLight,
-                                      shape: RoundedRectangleBorder(
-                                        borderRadius: BorderRadius.circular(8),
+                                    StatefulBuilder(
+                                      builder: (BuildContext context,
+                                              StateSetter _setState) =>
+                                          CheckboxListTile(
+                                        activeColor: ThemeProvider
+                                            .theme.primaryColorDark,
+                                        tileColor: ThemeProvider
+                                            .theme.primaryColorLight,
+                                        shape: RoundedRectangleBorder(
+                                          borderRadius:
+                                              BorderRadius.circular(8),
+                                        ),
+                                        title: Text(
+                                          'Sequential Download',
+                                          style: TextStyle(fontSize: 14),
+                                        ),
+                                        value: sequentialDownload,
+                                        onChanged: (bool? value) {
+                                          _setState(() {
+                                            sequentialDownload = value ?? false;
+                                          });
+                                        },
                                       ),
-                                      title: Text(
-                                        'Sequential Download',
-                                        style: TextStyle(fontSize: 14),
-                                      ),
-                                      value: sequentialDownload,
-                                      onChanged: (bool? value) {
-                                        setState(() {
-                                          sequentialDownload = value ?? false;
-                                        });
-                                      },
                                     ),
-                                    CheckboxListTile(
-                                      activeColor:
-                                          ThemeProvider.theme.primaryColorDark,
-                                      tileColor:
-                                          ThemeProvider.theme.primaryColorLight,
-                                      shape: RoundedRectangleBorder(
-                                        borderRadius: BorderRadius.circular(8),
+                                    StatefulBuilder(
+                                      builder: (BuildContext context,
+                                              StateSetter _setState) =>
+                                          CheckboxListTile(
+                                        activeColor: ThemeProvider
+                                            .theme.primaryColorDark,
+                                        tileColor: ThemeProvider
+                                            .theme.primaryColorLight,
+                                        shape: RoundedRectangleBorder(
+                                          borderRadius:
+                                              BorderRadius.circular(8),
+                                        ),
+                                        title: Text(
+                                          'Completed',
+                                          style: TextStyle(fontSize: 14),
+                                        ),
+                                        value: completed,
+                                        onChanged: (bool? value) {
+                                          _setState(() {
+                                            completed = value ?? false;
+                                          });
+                                        },
                                       ),
-                                      title: Text(
-                                        'Completed',
-                                        style: TextStyle(fontSize: 14),
-                                      ),
-                                      value: completed,
-                                      onChanged: (bool? value) {
-                                        setState(() {
-                                          completed = value ?? false;
-                                        });
-                                      },
                                     ),
                                     SizedBox(
                                       height: 15,


### PR DESCRIPTION
F# Fixes #128 

- Describe the changes you have made in this PR :
Since the checkboxlisttile was in a bottomSheet it wasnt working as expected, now all checkboxlisttiles are wrapped with statefulbuilder which will listen to checkbox onclick even and repaints only the checkBox instead of whole sheet.


# Screenshots of the changes 

https://user-images.githubusercontent.com/93595710/212462379-5351b4d9-0898-41a3-9b3f-01b385c88b95.mp4

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


