### PR TITLE
Snackbar overflow issue resolved

### DIFF
--- a/lib/Components/flood_snackbar.dart
+++ b/lib/Components/flood_snackbar.dart
@@ -31,10 +31,14 @@ SnackBar addFloodSnackBar(
         SizedBox(
           width: 8,
         ),
-        Text(
-          title,
-          style: TextStyle(
-            color: Colors.white,
+        Expanded(
+          child: Text(
+            title,
+            overflow: TextOverflow.ellipsis,
+            maxLines: 2,
+            style: TextStyle(
+              color: Colors.white,
+            ),
           ),
         ),
       ],


### PR DESCRIPTION
Fixes: Text overflow issue in snackbar #163

Describe the changes you have made in this PR -

- Added overflow property to Text widget in snackbar.
- Wrapped Text widget in snackbar with an Expanded widget.

Screenshots of the changes (If any) -
![Screenshot (279)](https://user-images.githubusercontent.com/88512639/213776702-5eb46ba7-c3eb-4b70-83e8-422d1f712ba7.png)

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.
