### PR TITLE
fix unable to update many fields in setting page issue

### DIFF
--- a/lib/Pages/settings_screen.dart
+++ b/lib/Pages/settings_screen.dart
@@ -81,7 +81,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
   void didChangeDependencies() {
     // TODO: implement didChangeDependencies
     ClientSettingsModel model =
-        Provider.of<ClientSettingsProvider>(context).clientSettings;
+        Provider.of<ClientSettingsProvider>(context, listen: false)
+            .clientSettings;
     setState(() {
       // *Bandwidth Initialization
       globalDownloadRateController = new TextEditingController(


### PR DESCRIPTION
Fixes #60 

Describe the changes you have made in this PR -
I need to fix the issue of being unable to update multiple fields on the settings page. The problem arises from multiple invocations of the `didChangeDependencies` method. Whenever a change occurs in the `clientSettings`, the `didChangeDependencies` method is called, which overwrites the user-entered values. So, I have set `listen: false` for `ClientSettingsProvider` to prevent the reinitialization of every field when `clientSettings` changes.