### PR TITLE
fix button alignment in logout_alert_dialogue

### DIFF
--- a/lib/Components/logout_alert.dart
+++ b/lib/Components/logout_alert.dart
@@ -30,6 +30,7 @@ class LogOutAlert extends StatelessWidget {
         ),
       ),
       actionsPadding: EdgeInsets.all(5),
+      actionsAlignment: MainAxisAlignment.spaceEvenly,
       actions: [
         // No - TextButton
         TextButton(


### PR DESCRIPTION
Fixes #187 

Describe the changes you have made in this PR -
Make alignment of `spaceEvenly` so if there is blank space then `spaceEvenly` is looks nice.

Screenshots of the changes (If any) -
![Screenshot_1676188696 (New size 1)](https://user-images.githubusercontent.com/91112485/218299673-dff150f8-c1da-4d24-8fa2-fa629148a790.png)

