### PR TITLE
Fixed importing of Badge from 2 packages

### DIFF
--- a/lib/Pages/home_screen.dart
+++ b/lib/Pages/home_screen.dart
@@ -1,7 +1,7 @@
 import 'package:awesome_notifications/awesome_notifications.dart';
 import 'dart:convert';
 import 'dart:io';
-import 'package:badges/badges.dart';
+import 'package:badges/badges.dart' as badge;
 import 'package:dio/dio.dart';
 import 'package:flood_mobile/Api/client_api.dart';
 import 'package:flood_mobile/Api/notifications_api.dart';
@@ -180,7 +180,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   elevation: 0,
                   actions: [
                     RSSFeedButtonWidget(),
-                    Badge(
+                    badge.Badge(
                       showBadge:
                           homeModel.unreadNotifications == 0 ? false : true,
                       key: Key('Badge Widget'),
@@ -191,7 +191,7 @@ class _HomeScreenState extends State<HomeScreen> {
                           style: TextStyle(color: Colors.white),
                         ),
                       ),
-                      position: BadgePosition(top: 0, end: 3),
+                      position: badge.BadgePosition(top: 0, end: 3),
                       child: IconButton(
                         icon: Icon(
                           Icons.notifications,


### PR DESCRIPTION
fixes #199 

### Changes made in this PR
- changed `import 'package:badges/badges.dart'` to `import 'package:badges/badges.dart' as badge;` and called `Badge()` as `badge.Badge()` whereever needed.
