### PR TITLE
Automatic Dismissal of Torrent Download Notification When Torrent is Deleted

### DIFF
--- a/lib/Api/torrent_api.dart
+++ b/lib/Api/torrent_api.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:awesome_notifications/awesome_notifications.dart';
 import 'package:dio/dio.dart';
 import 'package:flood_mobile/Model/torrent_content_model.dart';
 import 'package:flood_mobile/Model/torrent_model.dart';
@@ -194,6 +195,7 @@ class TorrentApi {
   }
 
   static Future<void> deleteTorrent({
+    required int id,
     required String hash,
     required bool deleteWithData,
     required BuildContext context,
@@ -222,6 +224,7 @@ class TorrentApi {
       );
       if (response.statusCode == 200) {
         print('--TORRENT DELETED--');
+        AwesomeNotifications().dismiss(id);
       } else {}
     } catch (e) {
       print('--ERROR--');

--- a/lib/Components/delete_torrent_sheet.dart
+++ b/lib/Components/delete_torrent_sheet.dart
@@ -7,8 +7,9 @@ import 'flood_snackbar.dart';
 
 class DeleteTorrentSheet extends StatefulWidget {
   final TorrentModel torrent;
+  final int index;
 
-  DeleteTorrentSheet({required this.torrent});
+  DeleteTorrentSheet({required this.index, required this.torrent});
 
   @override
   _DeleteTorrentSheetState createState() => _DeleteTorrentSheetState();
@@ -109,6 +110,7 @@ class _DeleteTorrentSheetState extends State<DeleteTorrentSheet> {
                   child: ElevatedButton(
                     onPressed: () {
                       TorrentApi.deleteTorrent(
+                          id: widget.index,
                           hash: widget.torrent.hash,
                           deleteWithData: deleteWithData,
                           context: context);

--- a/lib/Components/torrent_tile.dart
+++ b/lib/Components/torrent_tile.dart
@@ -20,8 +20,9 @@ import 'flood_snackbar.dart';
 
 class TorrentTile extends StatefulWidget {
   final TorrentModel model;
+  final int index;
 
-  TorrentTile({required this.model});
+  TorrentTile({required this.model, required this.index});
 
   @override
   _TorrentTileState createState() => _TorrentTileState();
@@ -43,6 +44,7 @@ class _TorrentTileState extends State<TorrentTile> {
       backgroundColor: ThemeProvider.theme.scaffoldBackgroundColor,
       builder: (context) {
         return DeleteTorrentSheet(
+          index: widget.index,
           torrent: widget.model,
         );
       },

--- a/lib/Pages/torrent_screen.dart
+++ b/lib/Pages/torrent_screen.dart
@@ -65,6 +65,7 @@ class _TorrentScreenState extends State<TorrentScreen> {
                                 .toLowerCase()
                                 .contains(keyword.toLowerCase())) {
                               return TorrentTile(
+                                  index: index,
                                   model: model.torrentList[index]);
                             }
                           }


### PR DESCRIPTION
fixes #195 

### Changes made in this PR 
- Made the notification for a downloading torrent dismiss automatically whenever we delete the corresponding torrent
- I hade made this by adding `AwesomeNotifications().dismiss(id);` in [torrent_api.dart](https://github.com/CCExtractor/Flood_Mobile/blob/master/lib/Api/torrent_api.dart), which basically dismisses the notification for the corresponding downloading torrent by the given id or index of the torrent.

### Screen Recording


https://user-images.githubusercontent.com/83648898/223203415-87d1ce35-d094-4e82-8e24-9e67a41bcf36.mp4

