### PR TITLE
docx: Create document.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/document.md
+++ b/.github/ISSUE_TEMPLATE/document.md
@@ -1,0 +1,26 @@
+## Document Issue
+
+**Affected document**
+Please specify which document(s) are affected.
+
+**Describe the issue**
+A clear and concise description of what the issue is.
+
+**Screenshots**
+If applicable, add screenshots to help explain the issue.
+
+**Additional context**
+Add any other context about the problem here.
+
+## Checklist
+- [ ] I have searched for similar issues in the repository.
+- [ ] I have read the contributing guidelines.
+- [ ] I have provided a clear and concise description of the issue.
+- [ ] I have provided steps to reproduce the issue.
+- [ ] I have included any relevant screenshots.
+
+## Definition of Done
+- [ ] The issue has been resolved.
+- [ ] The document has been updated to reflect the resolution.
+- [ ] The updated document has been reviewed by at least one other team member.
+- [ ] The changes have been merged into the main branch.


### PR DESCRIPTION
we only have 2 issue templates Its a good idea to have document issue template separate since the project is growing 

Describe the changes you have made in this PR ?

I have simply added new template in issue_templates named document.md 

**Documentation issue template:** This template should allow users to report issues or inconsistencies in the documentation for the app. It should include fields for the user to describe the issue, the section of the documentation it pertains to, and any suggested changes or corrections.

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.
checked 