### PR TITLE
issue 129 show list of users in setting screen

### DIFF
--- a/lib/Api/auth_api.dart
+++ b/lib/Api/auth_api.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:flood_mobile/Model/register_user_model.dart';
 import 'package:flood_mobile/Provider/user_detail_provider.dart';
+import 'package:flood_mobile/Model/current_user_detail_model.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -45,8 +46,9 @@ class AuthApi {
           // Setting token in shared preference
           SharedPreferences prefs = await SharedPreferences.getInstance();
           await prefs.setString('floodToken', token);
+          await prefs.setString('floodUsername', username);
           Provider.of<UserDetailProvider>(context, listen: false)
-              .setToken(token);
+              .setUserDetails(token, username);
           return true;
         }
         return false;
@@ -82,8 +84,73 @@ class AuthApi {
       print(rawBody);
       response = await dio
           .post(url, data: rawBody, queryParameters: {"cookie": false});
-      print(response);
       if (response.statusCode == 200) {
+        print(response);
+        getUsersList(context);
+      } else {}
+    } catch (e) {
+      print('--ERROR--');
+      print(e.toString());
+    }
+  }
+
+  static getUsersList(BuildContext context) async {
+    try {
+      String url = Provider.of<ApiProvider>(context, listen: false).baseUrl +
+          ApiProvider.getUsersList;
+      print('---GET USERS LIST---');
+      print(url);
+      Response response;
+      Dio dio = new Dio();
+      //Headers
+      dio.options.headers['Accept'] = "application/json";
+      dio.options.headers['Content-Type'] = "application/json";
+      dio.options.headers['Connection'] = "keep-alive";
+      dio.options.headers['Cookie'] =
+          Provider.of<UserDetailProvider>(context, listen: false).token;
+      response = await dio.get(
+        url,
+      );
+      if (response.statusCode == 200) {
+        List<CurrentUserDetailModel> usersList = [];
+        for (final user in response.data) {
+          usersList.add(CurrentUserDetailModel.fromJson(user));
+        }
+        Provider.of<UserDetailProvider>(context, listen: false)
+            .setUsersList(usersList);
+        print('---USERS LIST---');
+        print(response);
+      } else {}
+    } catch (e) {
+      print('--ERROR--');
+      print(e.toString());
+    }
+  }
+
+  static deleteUser(BuildContext context, String username) async {
+    try {
+      String url = Provider.of<ApiProvider>(context, listen: false).baseUrl +
+          ApiProvider.deleteUser +
+          "/" +
+          username;
+      print('---DELETE USER---');
+      print(url);
+      Response response;
+      Dio dio = new Dio();
+      //Headers
+      dio.options.headers['Accept'] = "application/json";
+      dio.options.headers['Content-Type'] = "application/json";
+      dio.options.headers['Connection'] = "keep-alive";
+      dio.options.headers['Cookie'] =
+          Provider.of<UserDetailProvider>(context, listen: false).token;
+      response = await dio.delete(
+        url,
+      );
+      if (response.statusCode == 200) {
+        print(response);
+        print('---USER DELETED---');
+        // *Getting the users list again
+        getUsersList(context);
       } else {}
     } catch (e) {
       print('--ERROR--');

--- a/lib/Components/user_list.dart
+++ b/lib/Components/user_list.dart
@@ -1,0 +1,86 @@
+import 'package:flood_mobile/Api/auth_api.dart';
+import 'package:flood_mobile/Constants/theme_provider.dart';
+import 'package:flood_mobile/Model/current_user_detail_model.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class UsersListView extends StatelessWidget {
+  final List<CurrentUserDetailModel> usersList;
+  final String currentUsername;
+
+  const UsersListView({
+    Key? key,
+    required this.usersList,
+    required this.currentUsername,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      shrinkWrap: true,
+      itemCount: usersList.length,
+      itemBuilder: (context, index) {
+        return Container(
+          height: 50.0,
+          padding: EdgeInsets.symmetric(vertical: 5),
+          decoration: BoxDecoration(
+            color: ThemeProvider.theme.primaryColorLight,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(
+              color: ThemeProvider.theme.primaryColor,
+              width: 1.0,
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Text(
+                  usersList[index].username,
+                  style: TextStyle(
+                    color: ThemeProvider.theme.textTheme.bodyText1?.color,
+                  ),
+                ),
+                Spacer(),
+                (usersList[index].username == currentUsername)
+                    ? Container(
+                        decoration: BoxDecoration(
+                          color: ThemeProvider.theme.highlightColor,
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 6.0,
+                            vertical: 4.0,
+                          ),
+                          child: Text(
+                            'Current User',
+                            style: TextStyle(
+                                color: ThemeProvider.theme.primaryColor),
+                          ),
+                        ),
+                      )
+                    : Center(
+                        child: IconButton(
+                          padding: EdgeInsets.zero,
+                          onPressed: () {
+                            AuthApi.deleteUser(
+                                context, usersList[index].username);
+                          },
+                          icon: Icon(
+                            Icons.close,
+                            size: 20.0,
+                          ),
+                        ),
+                      ),
+                SizedBox(
+                  width: 8.0,
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/Constants/theme_provider.dart
+++ b/lib/Constants/theme_provider.dart
@@ -38,6 +38,8 @@ class MyThemes {
         color: Colors.white,
       ),
     ),
+    highlightColor: Color(0xff415062),
+    errorColor: Color(0xffF34570),
   );
   static final lightTheme = ThemeData(
     brightness: Brightness.light,
@@ -62,5 +64,7 @@ class MyThemes {
         color: Colors.black,
       ),
     ),
+    highlightColor: Color(0xff415062),
+    errorColor: Color(0xffF34570),
   );
 }

--- a/lib/Pages/home_screen.dart
+++ b/lib/Pages/home_screen.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:badges/badges.dart';
 import 'package:dio/dio.dart';
+import 'package:flood_mobile/Api/auth_api.dart';
 import 'package:flood_mobile/Api/client_api.dart';
 import 'package:flood_mobile/Api/notifications_api.dart';
 import 'package:flood_mobile/Components/add_automatic_torrent.dart';
@@ -13,6 +14,7 @@ import 'package:flood_mobile/Components/nav_drawer_list_tile.dart';
 import 'package:flood_mobile/Components/notification_popup_dialogue_container.dart';
 import 'package:flood_mobile/Components/toast_component.dart';
 import 'package:flood_mobile/Constants/theme_provider.dart';
+import 'package:flood_mobile/Model/current_user_detail_model.dart';
 import 'package:flood_mobile/Pages/about_screen.dart';
 import 'package:flood_mobile/Pages/settings_screen.dart';
 import 'package:flood_mobile/Pages/torrent_screen.dart';
@@ -60,6 +62,7 @@ class _HomeScreenState extends State<HomeScreen> {
     );
     _processInitialUri();
     _listenForUri();
+    AuthApi.getUsersList(context);
   }
 
   @override
@@ -450,8 +453,11 @@ class _MenuState extends State<Menu> {
                       SharedPreferences prefs =
                           await SharedPreferences.getInstance();
                       prefs.setString('floodToken', '');
+                      prefs.setString('floodUsername', '');
                       Provider.of<UserDetailProvider>(context, listen: false)
-                          .setToken('');
+                          .setUserDetails('', '');
+                      Provider.of<UserDetailProvider>(context, listen: false)
+                          .setUsersList(<CurrentUserDetailModel>[]);
                       Navigator.of(context).pushNamedAndRemoveUntil(
                           Routes.loginScreenRoute,
                           (Route<dynamic> route) => false);

--- a/lib/Pages/splash_screen.dart
+++ b/lib/Pages/splash_screen.dart
@@ -28,19 +28,32 @@ class _SplashScreenState extends State<SplashScreen> {
     String token = prefs.getString('floodToken') ?? '';
     print('Token: ' + token);
     String baseUrl = prefs.getString('baseUrl') ?? '';
-    if (token != '' && baseUrl != '' && loggedInBefore == true) {
-      Provider.of<UserDetailProvider>(context, listen: false).setToken(token);
+    String username = prefs.getString('floodUsername') ?? '';
+    if (token != '' &&
+        baseUrl != '' &&
+        username != '' &&
+        loggedInBefore == true) {
+      Provider.of<UserDetailProvider>(context, listen: false).setUserDetails(
+        token,
+        username,
+      );
       Provider.of<ApiProvider>(context, listen: false).setBaseUrl(baseUrl);
       Navigator.of(context).pushNamedAndRemoveUntil(
           Routes.homeScreenRoute, (Route<dynamic> route) => false);
     }
-    if (token == '' && baseUrl == '' && loggedInBefore == false) {
+    if (token == '' &&
+        baseUrl == '' &&
+        username == '' &&
+        loggedInBefore == false) {
       Provider.of<LoginStatusDataProvider>(context, listen: false)
           .setLoggedInStatus(true);
       Navigator.of(context)
           .push(MaterialPageRoute(builder: (context) => OnboardingMainPage()));
     }
-    if (token == '' && baseUrl == '' && loggedInBefore == true) {
+    if (token == '' &&
+        baseUrl == '' &&
+        username == '' &&
+        loggedInBefore == true) {
       Navigator.of(context).pushNamedAndRemoveUntil(
           Routes.loginScreenRoute, (Route<dynamic> route) => false);
     }

--- a/lib/Provider/api_provider.dart
+++ b/lib/Provider/api_provider.dart
@@ -4,8 +4,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 class ApiProvider extends ChangeNotifier {
   String baseUrl = 'http://localhost:3000';
   static String authenticateUrl = '/api/auth/authenticate';
-  static String getCurrentUserDetails = '/api/auth/users';
+  static String getUsersList = '/api/auth/users';
   static String registerUser = '/api/auth/register';
+  static String deleteUser = '/api/auth/users';
   static String startTorrentUrl = '/api/torrents/start';
   static String getTorrentListUrl = '/api/torrents';
   static String stopTorrentUrl = '/api/torrents/stop';

--- a/lib/Provider/user_detail_provider.dart
+++ b/lib/Provider/user_detail_provider.dart
@@ -1,9 +1,19 @@
+import 'package:flood_mobile/Model/current_user_detail_model.dart';
 import 'package:flutter/cupertino.dart';
 
 class UserDetailProvider extends ChangeNotifier {
   String token = '';
-  void setToken(String newToken) {
+  String username = '';
+  late List<CurrentUserDetailModel> usersList = [];
+
+  void setUserDetails(String newToken, String newUsername) {
     token = newToken;
+    username = newUsername;
+    notifyListeners();
+  }
+
+  void setUsersList(newUsersList) {
+    usersList = newUsersList;
     notifyListeners();
   }
 }

--- a/test/user_detail_provider_unit_test.dart
+++ b/test/user_detail_provider_unit_test.dart
@@ -12,19 +12,24 @@ void main() {
     "initial values are correct",
     () {
       expect(sut.token, '');
+      expect(sut.username, '');
     },
   );
 
   group('setToken', () {
     final newToken = 'test token';
+    final newUsername = 'testUsername';
 
     test(
-      "tests setToken working",
+      "tests setUsersDetails working",
       () async {
         expect(sut.token.isEmpty, true);
-        sut.setToken(newToken);
+        expect(sut.username.isEmpty, true);
+        sut.setUserDetails(newToken, newUsername);
         expect(sut.token.isEmpty, false);
+        expect(sut.username.isEmpty, false);
         expect(sut.token, 'test token');
+        expect(sut.username, 'testUsername');
       },
     );
   });


### PR DESCRIPTION
Fixes #129 

Tasks achieved in this PR -

1. **Display the list of users**: Wrote a function `getUsersList` in `AuthApi` to find the list of users (Refer the attached picture).
2. **Delete a user**: If the current user is an admin, they will be able to delete any of the other users with a single tap. Wrote a function `deleteUser` in `AuthApi` which handles the API.
3. **Restrict non admin users from updating Authentication settings**: I check on Flood web app, if the user is not an admin, they are not able to change any of the settings under Authentication head, but this was not the case in the mobile app. So, I have handled the case when user is not an admin (Refer the attached picture).
4. Update tests for `UserDetailsProvider`: Because now username is also getting stored in `SharedPreferences` along with token, thus made the necessary changes in `user_detail_provider_unit_test.dart` to cover that portion too.
5. Reset text field after adding new user.

Screenshots of the changes -

**For non admin -**

![Screenshot 2023-05-13 1640361 (New size 1) (Phone)](https://github.com/CCExtractor/Flood_Mobile/assets/91112485/f6d94335-ac02-436a-8cda-b682e4e91a48)

**For admin -**

![Screenshot 2023-05-13 163933 (New size 1) (Phone)](https://github.com/CCExtractor/Flood_Mobile/assets/91112485/d4ba41cb-88ef-430e-92ba-fb4fbeb79497)

In PR #138, multiple API calls are being made repeatedly, causing the app to become sluggish. That's why I created a new PR addressing this issue.