### PR TITLE
fix: clear the textFields after saving on rssfeedhomepage

### DIFF
--- a/lib/Components/RSSFeedHomePage.dart
+++ b/lib/Components/RSSFeedHomePage.dart
@@ -76,6 +76,24 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
     super.initState();
   }
 
+  // clearing the fields in Feeds tabs after tappping save button
+  void clearFeedsFields() {
+    labelController.clear();
+    urlController.clear();
+    intervalController.clear();
+  }
+
+  void clearDownloadRulesFields() {
+    labelRulesController.clear();
+    matchpatternController.clear();
+    excludepatternController.clear();
+    destinationController.clear();
+    tagsController.clear();
+    startOnLoad = false;
+    useAsBasePath = false;
+    applicableFeedSelected = null;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Consumer<ClientSettingsProvider>(
@@ -710,6 +728,7 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                                                     FeedsApi
                                                         .listAllFeedsAndRules(
                                                             context: context);
+                                                    clearFeedsFields();
                                                     if (isUpdateFeedSelected) {
                                                       UpdateFeedApi.updateFeed(
                                                           type: "feed",
@@ -1756,6 +1775,7 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                                           MainAxisAlignment.center,
                                       children: [
                                         DropdownButtonFormField2(
+                                          value: applicableFeedSelected,
                                           decoration: InputDecoration(
                                             //Add isDense true and zero Padding.
                                             //Add Horizontal padding using buttonPadding and Vertical padding by increasing buttonHeight instead of add Padding here so that The whole TextFormField Button become clickable, and also the dropdown menu open under The whole TextFormField Button.
@@ -2240,6 +2260,7 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                                                     FeedsApi
                                                         .listAllFeedsAndRules(
                                                             context: context);
+                                                    clearDownloadRulesFields();
                                                   });
                                                 }
                                               },


### PR DESCRIPTION
Fixes #198 

Describe the changes you have made in this PR -

- added controller.clear() method to clear the text textFields
- added two functions that handles the clearing of the fields in Feed tab and Rules tab
- added comments for the controller functionality

Screenshots of the changes (If any) -

https://user-images.githubusercontent.com/93595710/223111004-374b04ed-f7e8-408e-9d88-effcb66ef84e.mp4

https://user-images.githubusercontent.com/93595710/223111005-22637e34-160b-4327-952f-57c07a3cdf5f.mp4
