### PR TITLE
added the feature to dismiss the notification when the torrent is deleted

### DIFF
--- a/lib/Api/torrent_api.dart
+++ b/lib/Api/torrent_api.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:awesome_notifications/awesome_notifications.dart';
 import 'package:dio/dio.dart';
 import 'package:flood_mobile/Model/torrent_content_model.dart';
 import 'package:flood_mobile/Model/torrent_model.dart';
@@ -194,6 +195,7 @@ class TorrentApi {
   }
 
   static Future<void> deleteTorrent({
+    required List<int> id,
     required List<String> hashes,
     required bool deleteWithData,
     required BuildContext context,
@@ -222,6 +224,9 @@ class TorrentApi {
       );
       if (response.statusCode == 200) {
         print('--TORRENT DELETED--');
+        id.forEach((element) {
+          AwesomeNotifications().dismiss(element);
+        });
       } else {}
     } catch (e) {
       print('--ERROR--');

--- a/lib/Components/delete_torrent_sheet.dart
+++ b/lib/Components/delete_torrent_sheet.dart
@@ -6,10 +6,14 @@ import 'package:flutter/material.dart';
 import 'flood_snackbar.dart';
 
 class DeleteTorrentSheet extends StatefulWidget {
-  final int index;
+  final int themeIndex;
   final List<TorrentModel> torrents;
+  final List<int> indexes;
 
-  DeleteTorrentSheet({required this.torrents, required this.index});
+  DeleteTorrentSheet(
+      {required this.torrents,
+      required this.indexes,
+      required this.themeIndex});
 
   @override
   _DeleteTorrentSheetState createState() => _DeleteTorrentSheetState();
@@ -52,7 +56,8 @@ class _DeleteTorrentSheetState extends State<DeleteTorrentSheet> {
               Checkbox(
                 key: Key('Checkbox delete with data'),
                 value: deleteWithData,
-                activeColor: ThemeProvider.theme(widget.index).primaryColorDark,
+                activeColor:
+                    ThemeProvider.theme(widget.themeIndex).primaryColorDark,
                 onChanged: (bool? value) {
                   setState(() {
                     deleteWithData = value ?? false;
@@ -90,7 +95,7 @@ class _DeleteTorrentSheetState extends State<DeleteTorrentSheet> {
                       child: Text(
                         "No",
                         style: TextStyle(
-                          color: ThemeProvider.theme(widget.index)
+                          color: ThemeProvider.theme(widget.themeIndex)
                               .textTheme
                               .bodyLarge
                               ?.color,
@@ -118,6 +123,7 @@ class _DeleteTorrentSheetState extends State<DeleteTorrentSheet> {
                         hashes.add(element.hash);
                       });
                       TorrentApi.deleteTorrent(
+                          id: widget.indexes,
                           hashes: hashes,
                           deleteWithData: deleteWithData,
                           context: context);
@@ -136,14 +142,14 @@ class _DeleteTorrentSheetState extends State<DeleteTorrentSheet> {
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(14.0),
                       ),
-                      backgroundColor:
-                          ThemeProvider.theme(widget.index).primaryColorDark,
+                      backgroundColor: ThemeProvider.theme(widget.themeIndex)
+                          .primaryColorDark,
                     ),
                     child: Center(
                       child: Text(
                         "Yes",
                         style: TextStyle(
-                          color: ThemeProvider.theme(widget.index)
+                          color: ThemeProvider.theme(widget.themeIndex)
                               .textTheme
                               .bodyLarge
                               ?.color,

--- a/lib/Components/torrent_tile.dart
+++ b/lib/Components/torrent_tile.dart
@@ -22,8 +22,11 @@ import 'flood_snackbar.dart';
 
 class TorrentTile extends StatefulWidget {
   final TorrentModel model;
-  final int index;
-  TorrentTile({required this.model, required this.index});
+  final int themeIndex;
+  final List<int> indexes;
+
+  TorrentTile(
+      {required this.model, required this.themeIndex, required this.indexes});
 
   @override
   _TorrentTileState createState() => _TorrentTileState();
@@ -43,11 +46,12 @@ class _TorrentTileState extends State<TorrentTile> {
       isScrollControlled: true,
       context: context,
       backgroundColor:
-          ThemeProvider.theme(widget.index).scaffoldBackgroundColor,
+          ThemeProvider.theme(widget.themeIndex).scaffoldBackgroundColor,
       builder: (context) {
         return DeleteTorrentSheet(
           torrents: [widget.model],
-          index: widget.index,
+          themeIndex: widget.themeIndex,
+          indexes: widget.indexes,
         );
       },
     );
@@ -79,14 +83,16 @@ class _TorrentTileState extends State<TorrentTile> {
                 child: Center(
                   child: Checkbox(
                     activeColor:
-                        ThemeProvider.theme(widget.index).primaryColorDark,
+                        ThemeProvider.theme(widget.themeIndex).primaryColorDark,
                     value: selectTorrent.selectedTorrentList
                         .any((element) => element.hash == widget.model.hash),
                     onChanged: (bool? value) {
-                      if (value == true) {
+                      if (value!) {
                         selectTorrent.addItemToList(widget.model);
+                        selectTorrent.addIndexToList(widget.indexes);
                       } else {
                         selectTorrent.removeItemFromList(widget.model);
+                        selectTorrent.removeIndexFromList(widget.indexes);
                       }
                     },
                   ),
@@ -102,7 +108,7 @@ class _TorrentTileState extends State<TorrentTile> {
                 child: FocusedMenuHolder(
                   key: Key('Long Press Torrent Tile Menu'),
                   menuBoxDecoration: BoxDecoration(
-                      color: ThemeProvider.theme(widget.index)
+                      color: ThemeProvider.theme(widget.themeIndex)
                           .textTheme
                           .bodyLarge
                           ?.color,
@@ -128,7 +134,9 @@ class _TorrentTileState extends State<TorrentTile> {
                       onPressed: () {
                         selectTorrent.changeSelectionMode();
                         selectTorrent.removeAllItemsFromList();
+                        selectTorrent.removeAllIndexFromList();
                         selectTorrent.addItemToList(widget.model);
+                        selectTorrent.addIndexToList(widget.indexes);
                       },
                     ),
                     FocusedMenuItem(
@@ -148,7 +156,7 @@ class _TorrentTileState extends State<TorrentTile> {
                           context: context,
                           builder: (context) => AddTagDialogue(
                             torrents: [widget.model],
-                            index: widget.index,
+                            index: widget.themeIndex,
                           ),
                         );
                       },
@@ -196,7 +204,7 @@ class _TorrentTileState extends State<TorrentTile> {
                       ),
                       trailingIcon: Icon(
                         Icons.delete,
-                        color: ThemeProvider.theme(widget.index)
+                        color: ThemeProvider.theme(widget.themeIndex)
                             .textTheme
                             .bodyLarge
                             ?.color,
@@ -215,10 +223,12 @@ class _TorrentTileState extends State<TorrentTile> {
                     },
                     elevation: 0,
                     expandedColor:
-                        ThemeProvider.theme(widget.index).primaryColor,
-                    baseColor: ThemeProvider.theme(widget.index).primaryColor,
-                    expandedTextColor:
-                        ThemeProvider.theme(widget.index).colorScheme.secondary,
+                        ThemeProvider.theme(widget.themeIndex).primaryColor,
+                    baseColor:
+                        ThemeProvider.theme(widget.themeIndex).primaryColor,
+                    expandedTextColor: ThemeProvider.theme(widget.themeIndex)
+                        .colorScheme
+                        .secondary,
                     title: ListTile(
                       key: Key(widget.model.hash),
                       contentPadding: EdgeInsets.all(0),
@@ -226,7 +236,7 @@ class _TorrentTileState extends State<TorrentTile> {
                         widget.model.name,
                         overflow: TextOverflow.ellipsis,
                         style: TextStyle(
-                          color: ThemeProvider.theme(widget.index)
+                          color: ThemeProvider.theme(widget.themeIndex)
                               .textTheme
                               .bodyLarge
                               ?.color,
@@ -249,14 +259,14 @@ class _TorrentTileState extends State<TorrentTile> {
                                             .roundToDouble() /
                                         100,
                                     backgroundColor:
-                                        ThemeProvider.theme(widget.index)
+                                        ThemeProvider.theme(widget.themeIndex)
                                             .colorScheme
                                             .secondary
                                             .withAlpha(80),
                                     progressColor: (widget.model.percentComplete
                                                 .toStringAsFixed(1) ==
                                             '100.0')
-                                        ? ThemeProvider.theme(widget.index)
+                                        ? ThemeProvider.theme(widget.themeIndex)
                                             .primaryColorDark
                                         : Colors.blue,
                                   ),
@@ -280,10 +290,11 @@ class _TorrentTileState extends State<TorrentTile> {
                                       : 'Stopped  ',
                                   key: Key('status widget'),
                                   style: TextStyle(
-                                    color: ThemeProvider.theme(widget.index)
-                                        .textTheme
-                                        .bodyLarge
-                                        ?.color,
+                                    color:
+                                        ThemeProvider.theme(widget.themeIndex)
+                                            .textTheme
+                                            .bodyLarge
+                                            ?.color,
                                   ),
                                 ),
                                 Flexible(
@@ -300,7 +311,8 @@ class _TorrentTileState extends State<TorrentTile> {
                                     overflow: TextOverflow.ellipsis,
                                     key: Key('eta widget'),
                                     style: TextStyle(
-                                        color: ThemeProvider.theme(widget.index)
+                                        color: ThemeProvider.theme(
+                                                widget.themeIndex)
                                             .textTheme
                                             .bodyLarge
                                             ?.color),
@@ -317,20 +329,22 @@ class _TorrentTileState extends State<TorrentTile> {
                                 Text(
                                   filesize(widget.model.bytesDone.toInt()),
                                   style: TextStyle(
-                                    color: ThemeProvider.theme(widget.index)
-                                        .textTheme
-                                        .bodyLarge
-                                        ?.color,
+                                    color:
+                                        ThemeProvider.theme(widget.themeIndex)
+                                            .textTheme
+                                            .bodyLarge
+                                            ?.color,
                                   ),
                                 ),
                                 Text(' / '),
                                 Text(
                                   filesize(widget.model.sizeBytes.toInt()),
                                   style: TextStyle(
-                                    color: ThemeProvider.theme(widget.index)
-                                        .textTheme
-                                        .bodyLarge
-                                        ?.color,
+                                    color:
+                                        ThemeProvider.theme(widget.themeIndex)
+                                            .textTheme
+                                            .bodyLarge
+                                            ?.color,
                                   ),
                                 ),
                               ],
@@ -348,16 +362,18 @@ class _TorrentTileState extends State<TorrentTile> {
                                   width: 30,
                                   height: 30,
                                   decoration: BoxDecoration(
-                                    color: ThemeProvider.theme(widget.index)
-                                        .textTheme
-                                        .bodyLarge
-                                        ?.color,
+                                    color:
+                                        ThemeProvider.theme(widget.themeIndex)
+                                            .textTheme
+                                            .bodyLarge
+                                            ?.color,
                                     borderRadius: BorderRadius.circular(50),
                                   ),
                                   child: Icon(
                                     Icons.stop,
-                                    color: ThemeProvider.theme(widget.index)
-                                        .primaryColor,
+                                    color:
+                                        ThemeProvider.theme(widget.themeIndex)
+                                            .primaryColor,
                                   ),
                                 ),
                                 onTap: () {
@@ -371,16 +387,18 @@ class _TorrentTileState extends State<TorrentTile> {
                                   width: 30,
                                   height: 30,
                                   decoration: BoxDecoration(
-                                    color: ThemeProvider.theme(widget.index)
-                                        .textTheme
-                                        .bodyLarge
-                                        ?.color,
+                                    color:
+                                        ThemeProvider.theme(widget.themeIndex)
+                                            .textTheme
+                                            .bodyLarge
+                                            ?.color,
                                     borderRadius: BorderRadius.circular(50),
                                   ),
                                   child: Icon(
                                     Icons.play_arrow,
-                                    color: ThemeProvider.theme(widget.index)
-                                        .primaryColor,
+                                    color:
+                                        ThemeProvider.theme(widget.themeIndex)
+                                            .primaryColor,
                                   ),
                                 ),
                                 onTap: () {
@@ -400,8 +418,8 @@ class _TorrentTileState extends State<TorrentTile> {
                     ),
                     children: [
                       Card(
-                        color:
-                            ThemeProvider.theme(widget.index).primaryColorLight,
+                        color: ThemeProvider.theme(widget.themeIndex)
+                            .primaryColorLight,
                         child: Padding(
                           padding: EdgeInsets.all(15),
                           child: Column(
@@ -413,10 +431,11 @@ class _TorrentTileState extends State<TorrentTile> {
                               Text(
                                 'General',
                                 style: TextStyle(
-                                    color: ThemeProvider.theme(widget.index)
-                                        .textTheme
-                                        .bodyLarge
-                                        ?.color,
+                                    color:
+                                        ThemeProvider.theme(widget.themeIndex)
+                                            .textTheme
+                                            .bodyLarge
+                                            ?.color,
                                     fontWeight: FontWeight.bold),
                               ),
                               SizedBox(
@@ -490,10 +509,11 @@ class _TorrentTileState extends State<TorrentTile> {
                               Text(
                                 'Transfer',
                                 style: TextStyle(
-                                    color: ThemeProvider.theme(widget.index)
-                                        .textTheme
-                                        .bodyLarge
-                                        ?.color,
+                                    color:
+                                        ThemeProvider.theme(widget.themeIndex)
+                                            .textTheme
+                                            .bodyLarge
+                                            ?.color,
                                     fontWeight: FontWeight.bold),
                               ),
                               SizedBox(
@@ -536,10 +556,11 @@ class _TorrentTileState extends State<TorrentTile> {
                               Text(
                                 'Torrent',
                                 style: TextStyle(
-                                    color: ThemeProvider.theme(widget.index)
-                                        .textTheme
-                                        .bodyLarge
-                                        ?.color,
+                                    color:
+                                        ThemeProvider.theme(widget.themeIndex)
+                                            .textTheme
+                                            .bodyLarge
+                                            ?.color,
                                     fontWeight: FontWeight.bold),
                               ),
                               SizedBox(
@@ -583,7 +604,7 @@ class _TorrentTileState extends State<TorrentTile> {
                                         arguments: TorrentContentPageArguments(
                                             hash: widget.model.hash,
                                             directory: widget.model.directory,
-                                            index: widget.index));
+                                            index: widget.themeIndex));
                                   },
                                   style: OutlinedButton.styleFrom(
                                     shape: RoundedRectangleBorder(
@@ -591,10 +612,11 @@ class _TorrentTileState extends State<TorrentTile> {
                                             BorderRadius.circular(8.0)),
                                     side: BorderSide(
                                       width: 1.0,
-                                      color: ThemeProvider.theme(widget.index)
-                                          .textTheme
-                                          .bodyLarge!
-                                          .color!,
+                                      color:
+                                          ThemeProvider.theme(widget.themeIndex)
+                                              .textTheme
+                                              .bodyLarge!
+                                              .color!,
                                       style: BorderStyle.solid,
                                     ),
                                   ),
@@ -603,7 +625,8 @@ class _TorrentTileState extends State<TorrentTile> {
                                     children: [
                                       Icon(
                                         Icons.file_copy_rounded,
-                                        color: ThemeProvider.theme(widget.index)
+                                        color: ThemeProvider.theme(
+                                                widget.themeIndex)
                                             .textTheme
                                             .bodyLarge
                                             ?.color,
@@ -614,11 +637,11 @@ class _TorrentTileState extends State<TorrentTile> {
                                       Text(
                                         "Files",
                                         style: TextStyle(
-                                          color:
-                                              ThemeProvider.theme(widget.index)
-                                                  .textTheme
-                                                  .bodyLarge
-                                                  ?.color,
+                                          color: ThemeProvider.theme(
+                                                  widget.themeIndex)
+                                              .textTheme
+                                              .bodyLarge
+                                              ?.color,
                                         ),
                                       ),
                                     ],

--- a/lib/Pages/home_screen.dart
+++ b/lib/Pages/home_screen.dart
@@ -150,7 +150,7 @@ class _HomeScreenState extends State<HomeScreen> {
         offset: Offset(mediaQuery.viewPadding.left + 115 + 23,
             mediaQuery.viewPadding.top + 35 + 25),
         duration: const Duration(milliseconds: 800),
-        childBuilder: (context, int index, bool needsSetup, int position,
+        childBuilder: (context, int themeIndex, bool needsSetup, int position,
             Function(int) updatePosition) {
           return KeyboardDismissOnTap(
             child: SimpleHiddenDrawer(
@@ -160,26 +160,26 @@ class _HomeScreenState extends State<HomeScreen> {
               contentCornerRadius: 40,
               menu: Menu(
                   toggleTheme: toggleTheme,
-                  index: index,
+                  index: themeIndex,
                   updatePosition: updatePosition),
               screenSelectedBuilder: (_, controller) {
                 Widget screenCurrent = Container();
                 switch (position) {
                   case 0:
-                    screenCurrent = TorrentScreen(index: index);
+                    screenCurrent = TorrentScreen(index: themeIndex);
                     break;
                   case 1:
-                    screenCurrent = TorrentScreen(index: index);
+                    screenCurrent = TorrentScreen(index: themeIndex);
                     break;
                   case 2:
-                    screenCurrent = SettingsScreen(index: index);
+                    screenCurrent = SettingsScreen(index: themeIndex);
                     break;
                   case 5:
-                    screenCurrent = AboutScreen(index: index);
+                    screenCurrent = AboutScreen(index: themeIndex);
                     break;
                 }
                 if (needsSetup) {
-                  if (index == 1) {
+                  if (themeIndex == 1) {
                     controller.open();
                   }
                 }
@@ -195,7 +195,7 @@ class _HomeScreenState extends State<HomeScreen> {
                               ? IconButton(
                                   icon: Icon(
                                     Icons.menu,
-                                    color: ThemeProvider.theme(index)
+                                    color: ThemeProvider.theme(themeIndex)
                                         .textTheme
                                         .bodyLarge
                                         ?.color,
@@ -209,6 +209,7 @@ class _HomeScreenState extends State<HomeScreen> {
                                     setState(() {
                                       selectTorrent.changeSelectionMode();
                                       selectTorrent.removeAllItemsFromList();
+                                      selectTorrent.removeAllIndexFromList();
                                     });
                                   },
                                   icon: Icon(Icons.close)),
@@ -222,18 +223,18 @@ class _HomeScreenState extends State<HomeScreen> {
                           ),
                           centerTitle: true,
                           backgroundColor:
-                              ThemeProvider.theme(index).primaryColor,
+                              ThemeProvider.theme(themeIndex).primaryColor,
                           elevation: 0,
                           actions: [
                             if (!selectTorrent.isSelectionMode)
-                              RSSFeedButtonWidget(index: index),
+                              RSSFeedButtonWidget(index: themeIndex),
                             if (!selectTorrent.isSelectionMode)
                               Badge(
                                 showBadge: homeModel.unreadNotifications == 0
                                     ? false
                                     : true,
                                 key: Key('Badge Widget'),
-                                badgeColor: ThemeProvider.theme(index)
+                                badgeColor: ThemeProvider.theme(themeIndex)
                                     .colorScheme
                                     .secondary,
                                 badgeContent: Center(
@@ -255,12 +256,12 @@ class _HomeScreenState extends State<HomeScreen> {
                                           key: Key('Notification Alert Dialog'),
                                           elevation: 0,
                                           backgroundColor:
-                                              ThemeProvider.theme(index)
+                                              ThemeProvider.theme(themeIndex)
                                                   .primaryColor,
                                           content:
                                               notificationPopupDialogueContainer(
                                             context: context,
-                                            index: index,
+                                            index: themeIndex,
                                           ),
                                         );
                                       },
@@ -270,17 +271,18 @@ class _HomeScreenState extends State<HomeScreen> {
                               ),
                             if (selectTorrent.isSelectionMode)
                               PopupMenuButton<String>(
-                                color: ThemeProvider.theme(index)
+                                color: ThemeProvider.theme(themeIndex)
                                     .primaryColorLight,
                                 icon: Icon(
                                   Icons.more_vert,
-                                  color: ThemeProvider.theme(index)
+                                  color: ThemeProvider.theme(themeIndex)
                                       .textTheme
                                       .bodyLarge
                                       ?.color,
                                 ),
                                 onSelected: (value) {
                                   List<String> hash = [];
+                                  List<int> index = [];
                                   selectTorrent.selectedTorrentList
                                       .toList()
                                       .forEach((element) {
@@ -288,8 +290,15 @@ class _HomeScreenState extends State<HomeScreen> {
                                   });
                                   if (value == 'Select All') {
                                     selectTorrent.removeAllItemsFromList();
+                                    selectTorrent.removeAllIndexFromList();
                                     selectTorrent.addAllItemsToList(
                                         homeModel.torrentList);
+                                    for (int i = 0;
+                                        i < homeModel.torrentList.length;
+                                        i++) {
+                                      index.add(i);
+                                    }
+                                    selectTorrent.addAllIndexToList(index);
                                   }
                                   if (value == 'Start') {
                                     TorrentApi.startTorrent(
@@ -312,14 +321,16 @@ class _HomeScreenState extends State<HomeScreen> {
                                       isScrollControlled: true,
                                       context: context,
                                       backgroundColor:
-                                          ThemeProvider.theme(index)
+                                          ThemeProvider.theme(themeIndex)
                                               .scaffoldBackgroundColor,
                                       builder: (context) {
                                         return DeleteTorrentSheet(
                                           torrents: selectTorrent
                                               .selectedTorrentList
                                               .toList(),
-                                          index: index,
+                                          themeIndex: themeIndex,
+                                          indexes: selectTorrent
+                                              .selectedTorrentIndex,
                                         );
                                       },
                                     );
@@ -332,11 +343,12 @@ class _HomeScreenState extends State<HomeScreen> {
                                               torrents: selectTorrent
                                                   .selectedTorrentList
                                                   .toList(),
-                                              index: index,
+                                              index: themeIndex,
                                             )).then((value) {
                                       setState(() {
                                         selectTorrent.changeSelectionMode();
                                         selectTorrent.removeAllItemsFromList();
+                                        selectTorrent.removeAllIndexFromList();
                                       });
                                     });
                                   }

--- a/lib/Pages/torrent_screen.dart
+++ b/lib/Pages/torrent_screen.dart
@@ -95,8 +95,9 @@ class _TorrentScreenState extends State<TorrentScreen> {
                                   .toLowerCase()
                                   .contains(keyword.toLowerCase())) {
                                 return TorrentTile(
+                                  indexes: [index],
                                   model: model.torrentList[index],
-                                  index: widget.index,
+                                  themeIndex: widget.index,
                                 );
                               }
                             }

--- a/lib/Provider/multiple_select_torrent_provider.dart
+++ b/lib/Provider/multiple_select_torrent_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 class MultipleSelectTorrentProvider extends ChangeNotifier {
   bool isSelectionMode = false;
   List<TorrentModel> selectedTorrentList = [];
+  List<int> selectedTorrentIndex = [];
 
   void changeSelectionMode() {
     isSelectionMode = !isSelectionMode;
@@ -27,6 +28,29 @@ class MultipleSelectTorrentProvider extends ChangeNotifier {
 
   void removeAllItemsFromList() {
     selectedTorrentList = [];
+    notifyListeners();
+  }
+
+  void addIndexToList(List<int> index) {
+    index.forEach((element) {
+      if (!selectedTorrentIndex.contains(element))
+        selectedTorrentIndex.add(element);
+    });
+    notifyListeners();
+  }
+
+  void removeIndexFromList(List<int> index) {
+    selectedTorrentIndex.removeWhere((element) => index.contains(element));
+    notifyListeners();
+  }
+
+  void addAllIndexToList(List<int> index) {
+    selectedTorrentIndex.addAll(index);
+    notifyListeners();
+  }
+
+  void removeAllIndexFromList() {
+    selectedTorrentIndex = [];
     notifyListeners();
   }
 }


### PR DESCRIPTION
Fixes #195 

### **Changes made in this PR**

- Made the notification for a downloading torrent dismiss automatically whenever we delete the corresponding torrent
- I hade made this by adding `AwesomeNotifications().dismiss(id);` in [torrent_api.dart](https://github.com/CCExtractor/Flood_Mobile/blob/master/lib/Api/torrent_api.dart), which basically dismisses the notification for the corresponding downloading torrent by the given id or index of the torrent.

Demo of the changes -

https://github.com/CCExtractor/Flood_Mobile/assets/91112485/58bed85d-3ed1-468d-98f4-ae2439d13b6a


