### PR TITLE
Fixed the overlapping text and skip button

### DIFF
--- a/lib/Components/onboarding/onboarding.dart
+++ b/lib/Components/onboarding/onboarding.dart
@@ -63,7 +63,7 @@ class _OnboardingState extends State<Onboarding> {
                 textBaseline: TextBaseline.alphabetic,
                 children: <Widget>[
                   Padding(
-                    padding: const EdgeInsets.only(left: 20.0),
+                    padding: const EdgeInsets.only(left: 20.0, bottom: 10.0),
                     child: Text(
                       'Explore Flood-Mobile',
                       style: TextStyle(
@@ -74,7 +74,7 @@ class _OnboardingState extends State<Onboarding> {
                     ),
                   ),
                   Padding(
-                    padding: const EdgeInsets.only(right: 32.0),
+                    padding: const EdgeInsets.only(right: 32.0, bottom: 10.0),
                     child: ElevatedButton(
                       onPressed: () {
                         Navigator.of(context).pushNamedAndRemoveUntil(


### PR DESCRIPTION
Fixes #183 

Describe the changes you have made in this PR -

- The text and the skip button at top of the screen on the onboarding page were overlapping with the container below. I've shifted them above by adding some padding so this doesn't happen

Screenshots of the changes (If any) -
![222328999-b0138a81-9bf5-4d4d-bd02-46b6b56ee921](https://github.com/CCExtractor/Flood_Mobile/assets/91112485/0977b49b-d768-4f8e-af4b-f2a3599a961e)

