### PR TITLE
fixed RSS-Feed's browse feeds theme issue

### DIFF
--- a/lib/Components/RSSFeedHomePage.dart
+++ b/lib/Components/RSSFeedHomePage.dart
@@ -1262,7 +1262,10 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                                   ),
                                   Container(
                                     decoration: BoxDecoration(
-                                      border: Border.all(color: Colors.white38),
+                                      border: Border.all(
+                                          color:
+                                              ThemeProvider.theme(widget.index)
+                                                  .disabledColor),
                                       borderRadius: BorderRadius.only(
                                         topRight: Radius.circular(8),
                                         topLeft: Radius.circular(8),
@@ -1339,8 +1342,10 @@ class _RSSFeedHomePageState extends State<RSSFeedHomePage>
                                                                     .infinity,
                                                                 decoration:
                                                                     BoxDecoration(
-                                                                  color: Colors
-                                                                      .white12,
+                                                                  color: ThemeProvider.theme(
+                                                                          widget
+                                                                              .index)
+                                                                      .dividerColor,
                                                                 ),
                                                               ),
                                                             )

--- a/lib/Constants/theme_provider.dart
+++ b/lib/Constants/theme_provider.dart
@@ -41,6 +41,8 @@ class MyThemes {
       ),
     ),
     highlightColor: Color(0xff415062),
+    disabledColor: Colors.white38,
+    dividerColor: Colors.white12,
   );
   static final lightTheme = ThemeData(
     brightness: Brightness.light,
@@ -69,5 +71,7 @@ class MyThemes {
       ),
     ),
     highlightColor: Color(0xff415062),
+    disabledColor: Colors.black38,
+    dividerColor: Colors.black12,
   );
 }


### PR DESCRIPTION
Fixes #196 

**Describe the changes you have made in this PR -**
fix theme issue at `RSSFeedHomePage` by declare global theme variable `disabledColor` and `dividerColor`

Screenshots of the changes  -

 **- Light Mode**
![Screenshot_1684559130](https://github.com/CCExtractor/Flood_Mobile/assets/91112485/9a3d785b-48bd-40d6-846a-220ad57e21f0)

 **- Dark Mode**
![Screenshot_1684559121](https://github.com/CCExtractor/Flood_Mobile/assets/91112485/d655d0e6-1476-43ec-882a-0de5d8c5025d)

