### PR TITLE
fix play/pause button issue on add torrent by file

### DIFF
--- a/lib/Api/event_handler_api.dart
+++ b/lib/Api/event_handler_api.dart
@@ -101,6 +101,11 @@ class EventHandlerApi {
       try {
         TorrentModel torrentModel = TorrentModel.fromJson(newTorrentList[hash]);
         torrentModel.tags = torrentModel.tags.toSet().toList();
+        if (torrentModel.status.contains('stopped') &&
+            torrentModel.status.contains('downloading')) {
+          torrentModel.status
+              .removeWhere((element) => element.contains('downloading'));
+        }
         torrentList.add(torrentModel);
       } catch (e) {
         print(e.toString());


### PR DESCRIPTION
### **Describe the changes you have made in this PR -**

When a user adds a torrent file, the downloading status is declared multiple times in the torrent status. As a result, there is always one downloading status in the torrent status, preventing us from seeing the play icon on the torrent tile.

In this pull request, I addressed this issue by checking each torrent's status. If both 'stopped' and 'downloading' statuses are present in the torrent status, it indicates a duplicate status, and I removed it.

