### PR TITLE
 Implement theme persistence throughout your app

### DIFF
--- a/lib/Components/dark_transition.dart
+++ b/lib/Components/dark_transition.dart
@@ -11,7 +11,8 @@ class DarkTransition extends StatefulWidget {
       this.themeController,
       this.radius,
       this.duration = const Duration(milliseconds: 400),
-      this.isDark = false})
+      this.isDark = false,
+      required this.themeIndex})
       : super(key: key);
 
   final Widget Function(BuildContext, int, bool, int, Function(int))
@@ -21,6 +22,7 @@ class DarkTransition extends StatefulWidget {
   final Offset offset;
   final double? radius;
   final Duration? duration;
+  final int themeIndex;
 
   @override
   _DarkTransitionState createState() => _DarkTransitionState();
@@ -139,11 +141,11 @@ class _DarkTransitionState extends State<DarkTransition>
         builder: (BuildContext context, Widget? child) {
           return Stack(
             children: [
-              _body(2, false),
+              _body(widget.themeIndex == 2 ? 2 : 1, false),
               ClipPath(
                   clipper: CircularClipper(
                       _animationController.value * radius, position),
-                  child: _body(1, _needsSetup)),
+                  child: _body(widget.themeIndex == 2 ? 1 : 2, _needsSetup)),
             ],
           );
         });

--- a/lib/Constants/theme_provider.dart
+++ b/lib/Constants/theme_provider.dart
@@ -1,18 +1,31 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class ThemeProvider extends ChangeNotifier {
   static ThemeMode themeMode = ThemeMode.dark;
+
+  Future<void> getPreviousTheme() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    prefs.getString('themeMode') == 'ThemeMode.light'
+        ? themeMode = ThemeMode.light
+        : themeMode = ThemeMode.dark;
+
+    notifyListeners();
+  }
 
   bool get isDarkMode => themeMode == ThemeMode.dark;
 
   static ThemeData theme(int index) =>
       index == 2 ? MyThemes.darkTheme : MyThemes.lightTheme;
 
-  void toggleTheme() {
+  void toggleTheme() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
     if (themeMode == ThemeMode.dark) {
       themeMode = ThemeMode.light;
+      prefs.setString('themeMode', 'ThemeMode.light');
     } else {
       themeMode = ThemeMode.dark;
+      prefs.setString('themeMode', 'ThemeMode.dark');
     }
   }
 }

--- a/lib/Pages/home_screen.dart
+++ b/lib/Pages/home_screen.dart
@@ -42,8 +42,11 @@ import '../Constants/notification_keys.dart';
 import '../Components/RSSFeedButtonWidget.dart';
 
 class HomeScreen extends StatefulWidget {
+  final int? themeIndex;
   final GlobalKey<NavigatorState> navigatorKey =
       new GlobalKey<NavigatorState>();
+
+  HomeScreen({Key? key, this.themeIndex}) : super(key: key);
   @override
   _HomeScreenState createState() => _HomeScreenState();
 }
@@ -147,6 +150,7 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget build(BuildContext context) {
     final mediaQuery = MediaQuery.of(context);
     return DarkTransition(
+        themeIndex: widget.themeIndex ?? 2,
         isDark: isDark,
         offset: Offset(mediaQuery.viewPadding.left + 115 + 23,
             mediaQuery.viewPadding.top + 35 + 25),
@@ -180,7 +184,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     screenCurrent = AboutScreen(index: themeIndex);
                     break;
                 }
-                if (needsSetup && themeIndex == 1) {
+                if (needsSetup) {
                   SchedulerBinding.instance.addPostFrameCallback((_) {
                     controller.open();
                   });
@@ -530,8 +534,10 @@ class _MenuState extends State<Menu> {
                       Provider.of<UserDetailProvider>(context, listen: false)
                           .setUsersList(<CurrentUserDetailModel>[]);
                       Navigator.of(context).pushNamedAndRemoveUntil(
-                          Routes.loginScreenRoute,
-                          (Route<dynamic> route) => false);
+                        Routes.loginScreenRoute,
+                        (Route<dynamic> route) => false,
+                        arguments: widget.index,
+                      );
                     },
                     index: widget.index,
                   ),

--- a/lib/Pages/login_screen.dart
+++ b/lib/Pages/login_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:clipboard/clipboard.dart';
 import 'package:flood_mobile/Api/auth_api.dart';
 import 'package:flood_mobile/Components/toast_component.dart';
@@ -14,6 +16,9 @@ import '../Components/custom_dialog_animation.dart';
 import '../Provider/login_status_data_provider.dart';
 
 class LoginScreen extends StatefulWidget {
+  final int? themeIndex;
+
+  const LoginScreen({Key? key, this.themeIndex}) : super(key: key);
   @override
   _LoginScreenState createState() => _LoginScreenState();
 }
@@ -26,16 +31,23 @@ class _LoginScreenState extends State<LoginScreen> {
   TextEditingController urlController =
       new TextEditingController(text: 'http://localhost:3000');
   final _formKey = GlobalKey<FormState>();
+  late int themeIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    themeIndex = widget.themeIndex ?? 2;
+  }
 
   @override
   Widget build(BuildContext context) {
     double hp = MediaQuery.of(context).size.height;
     double wp = MediaQuery.of(context).size.width;
     return LoadingOverlay(
-      color: ThemeProvider.theme(2).primaryColor,
+      color: ThemeProvider.theme(themeIndex).primaryColor,
       isLoading: showSpinner,
       child: Scaffold(
-        backgroundColor: ThemeProvider.theme(2).primaryColor,
+        backgroundColor: ThemeProvider.theme(themeIndex).primaryColor,
         body: SafeArea(
           child: Form(
             key: _formKey,
@@ -59,7 +71,7 @@ class _LoginScreenState extends State<LoginScreen> {
                       Text(
                         'Welcome to Flood',
                         style: TextStyle(
-                            color: ThemeProvider.theme(2)
+                            color: ThemeProvider.theme(themeIndex)
                                 .textTheme
                                 .bodyLarge!
                                 .color!,
@@ -69,7 +81,7 @@ class _LoginScreenState extends State<LoginScreen> {
                       Text(
                         'Sign in to your account',
                         style: TextStyle(
-                            color: ThemeProvider.theme(2)
+                            color: ThemeProvider.theme(themeIndex)
                                 .textTheme
                                 .bodyLarge!
                                 .color!,
@@ -86,7 +98,7 @@ class _LoginScreenState extends State<LoginScreen> {
                               key: Key('Url TextField'),
                               controller: urlController,
                               style: TextStyle(
-                                color: ThemeProvider.theme(2)
+                                color: ThemeProvider.theme(themeIndex)
                                     .textTheme
                                     .bodyLarge
                                     ?.color,
@@ -94,7 +106,7 @@ class _LoginScreenState extends State<LoginScreen> {
                               decoration: InputDecoration(
                                 prefixIcon: Icon(
                                   Icons.link,
-                                  color: ThemeProvider.theme(2)
+                                  color: ThemeProvider.theme(themeIndex)
                                       .textTheme
                                       .bodyLarge!
                                       .color!,
@@ -103,19 +115,19 @@ class _LoginScreenState extends State<LoginScreen> {
                                 labelStyle: TextStyle(
                                     fontFamily: 'Montserrat',
                                     fontWeight: FontWeight.bold,
-                                    color: ThemeProvider.theme(2)
+                                    color: ThemeProvider.theme(themeIndex)
                                         .textTheme
                                         .bodyLarge!
                                         .color!),
                                 focusedBorder: UnderlineInputBorder(
                                   borderSide: BorderSide(
-                                    color:
-                                        ThemeProvider.theme(2).primaryColorDark,
+                                    color: ThemeProvider.theme(themeIndex)
+                                        .primaryColorDark,
                                   ),
                                 ),
                                 border: UnderlineInputBorder(
                                   borderSide: BorderSide(
-                                    color: ThemeProvider.theme(2)
+                                    color: ThemeProvider.theme(themeIndex)
                                         .textTheme
                                         .bodyLarge!
                                         .color!,
@@ -123,7 +135,7 @@ class _LoginScreenState extends State<LoginScreen> {
                                 ),
                                 disabledBorder: UnderlineInputBorder(
                                   borderSide: BorderSide(
-                                    color: ThemeProvider.theme(2)
+                                    color: ThemeProvider.theme(themeIndex)
                                         .textTheme
                                         .bodyLarge!
                                         .color!,
@@ -131,7 +143,7 @@ class _LoginScreenState extends State<LoginScreen> {
                                 ),
                                 enabledBorder: UnderlineInputBorder(
                                   borderSide: BorderSide(
-                                    color: ThemeProvider.theme(2)
+                                    color: ThemeProvider.theme(themeIndex)
                                         .textTheme
                                         .bodyLarge!
                                         .color!,
@@ -157,7 +169,7 @@ class _LoginScreenState extends State<LoginScreen> {
                                 },
                                 icon: Icon(
                                   Icons.paste,
-                                  color: ThemeProvider.theme(2)
+                                  color: ThemeProvider.theme(themeIndex)
                                       .textTheme
                                       .bodyLarge!
                                       .color!,
@@ -176,7 +188,7 @@ class _LoginScreenState extends State<LoginScreen> {
                           key: Key('Username TextField'),
                           controller: usernameController,
                           style: TextStyle(
-                            color: ThemeProvider.theme(2)
+                            color: ThemeProvider.theme(themeIndex)
                                 .textTheme
                                 .bodyLarge!
                                 .color!,
@@ -184,7 +196,7 @@ class _LoginScreenState extends State<LoginScreen> {
                           decoration: InputDecoration(
                             prefixIcon: Icon(
                               Icons.person,
-                              color: ThemeProvider.theme(2)
+                              color: ThemeProvider.theme(themeIndex)
                                   .textTheme
                                   .bodyLarge!
                                   .color!,
@@ -193,18 +205,19 @@ class _LoginScreenState extends State<LoginScreen> {
                             labelStyle: TextStyle(
                                 fontFamily: 'Montserrat',
                                 fontWeight: FontWeight.bold,
-                                color: ThemeProvider.theme(2)
+                                color: ThemeProvider.theme(themeIndex)
                                     .textTheme
                                     .bodyLarge!
                                     .color!),
                             focusedBorder: UnderlineInputBorder(
                               borderSide: BorderSide(
-                                color: ThemeProvider.theme(2).primaryColorDark,
+                                color: ThemeProvider.theme(themeIndex)
+                                    .primaryColorDark,
                               ),
                             ),
                             border: UnderlineInputBorder(
                               borderSide: BorderSide(
-                                color: ThemeProvider.theme(2)
+                                color: ThemeProvider.theme(themeIndex)
                                     .textTheme
                                     .bodyLarge!
                                     .color!,
@@ -212,7 +225,7 @@ class _LoginScreenState extends State<LoginScreen> {
                             ),
                             disabledBorder: UnderlineInputBorder(
                               borderSide: BorderSide(
-                                color: ThemeProvider.theme(2)
+                                color: ThemeProvider.theme(themeIndex)
                                     .textTheme
                                     .bodyLarge!
                                     .color!,
@@ -220,7 +233,7 @@ class _LoginScreenState extends State<LoginScreen> {
                             ),
                             enabledBorder: UnderlineInputBorder(
                               borderSide: BorderSide(
-                                color: ThemeProvider.theme(2)
+                                color: ThemeProvider.theme(themeIndex)
                                     .textTheme
                                     .bodyLarge!
                                     .color!,
@@ -245,7 +258,7 @@ class _LoginScreenState extends State<LoginScreen> {
                               key: Key('Password TextField'),
                               controller: passwordController,
                               style: TextStyle(
-                                color: ThemeProvider.theme(2)
+                                color: ThemeProvider.theme(themeIndex)
                                     .textTheme
                                     .bodyLarge
                                     ?.color,
@@ -254,7 +267,7 @@ class _LoginScreenState extends State<LoginScreen> {
                               decoration: InputDecoration(
                                 prefixIcon: Icon(
                                   Icons.lock_outline,
-                                  color: ThemeProvider.theme(2)
+                                  color: ThemeProvider.theme(themeIndex)
                                       .textTheme
                                       .bodyLarge!
                                       .color!,
@@ -262,19 +275,19 @@ class _LoginScreenState extends State<LoginScreen> {
                                 labelText: 'Password',
                                 labelStyle: TextStyle(
                                     fontWeight: FontWeight.bold,
-                                    color: ThemeProvider.theme(2)
+                                    color: ThemeProvider.theme(themeIndex)
                                         .textTheme
                                         .bodyLarge!
                                         .color!),
                                 focusedBorder: UnderlineInputBorder(
                                   borderSide: BorderSide(
-                                    color:
-                                        ThemeProvider.theme(2).primaryColorDark,
+                                    color: ThemeProvider.theme(themeIndex)
+                                        .primaryColorDark,
                                   ),
                                 ),
                                 border: UnderlineInputBorder(
                                   borderSide: BorderSide(
-                                    color: ThemeProvider.theme(2)
+                                    color: ThemeProvider.theme(themeIndex)
                                         .textTheme
                                         .bodyLarge!
                                         .color!,
@@ -282,7 +295,7 @@ class _LoginScreenState extends State<LoginScreen> {
                                 ),
                                 disabledBorder: UnderlineInputBorder(
                                   borderSide: BorderSide(
-                                    color: ThemeProvider.theme(2)
+                                    color: ThemeProvider.theme(themeIndex)
                                         .textTheme
                                         .bodyLarge!
                                         .color!,
@@ -290,7 +303,7 @@ class _LoginScreenState extends State<LoginScreen> {
                                 ),
                                 enabledBorder: UnderlineInputBorder(
                                   borderSide: BorderSide(
-                                    color: ThemeProvider.theme(2)
+                                    color: ThemeProvider.theme(themeIndex)
                                         .textTheme
                                         .bodyLarge!
                                         .color!,
@@ -316,7 +329,7 @@ class _LoginScreenState extends State<LoginScreen> {
                                   (showPass)
                                       ? Icons.visibility
                                       : Icons.visibility_off,
-                                  color: ThemeProvider.theme(2)
+                                  color: ThemeProvider.theme(themeIndex)
                                       .textTheme
                                       .bodyLarge!
                                       .color!,
@@ -352,8 +365,10 @@ class _LoginScreenState extends State<LoginScreen> {
                                 Toasts.showSuccessToast(
                                     msg: 'Login Successful');
                                 Navigator.of(context).pushNamedAndRemoveUntil(
-                                    Routes.homeScreenRoute,
-                                    (Route<dynamic> route) => false);
+                                  Routes.homeScreenRoute,
+                                  (Route<dynamic> route) => false,
+                                  arguments: themeIndex,
+                                );
                                 SharedPreferences prefs =
                                     await SharedPreferences.getInstance();
                                 bool batteryOptimizationInfoSeen =
@@ -407,8 +422,8 @@ class _LoginScreenState extends State<LoginScreen> {
                             shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(14.0),
                             ),
-                            backgroundColor:
-                                ThemeProvider.theme(2).primaryColorDark,
+                            backgroundColor: ThemeProvider.theme(themeIndex)
+                                .primaryColorDark,
                           ),
                           child: Center(
                             child: Text(

--- a/lib/Pages/splash_screen.dart
+++ b/lib/Pages/splash_screen.dart
@@ -10,14 +10,19 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class SplashScreen extends StatefulWidget {
+  final int? themeIndex;
+
+  const SplashScreen({Key? key, this.themeIndex}) : super(key: key);
   @override
   _SplashScreenState createState() => _SplashScreenState();
 }
 
 class _SplashScreenState extends State<SplashScreen> {
+  late int themeIndex;
   @override
   void initState() {
     super.initState();
+    themeIndex = widget.themeIndex ?? 2;
     new Timer(const Duration(seconds: 2), onEnd);
   }
 
@@ -28,6 +33,7 @@ class _SplashScreenState extends State<SplashScreen> {
     print('Token: ' + token);
     String baseUrl = prefs.getString('baseUrl') ?? '';
     String username = prefs.getString('floodUsername') ?? '';
+
     if (token != '' &&
         baseUrl != '' &&
         username != '' &&
@@ -38,7 +44,8 @@ class _SplashScreenState extends State<SplashScreen> {
       );
       Provider.of<ApiProvider>(context, listen: false).setBaseUrl(baseUrl);
       Navigator.of(context).pushNamedAndRemoveUntil(
-          Routes.homeScreenRoute, (Route<dynamic> route) => false);
+          Routes.homeScreenRoute, (Route<dynamic> route) => false,
+          arguments: themeIndex);
     }
     if (token == '' &&
         baseUrl == '' &&
@@ -54,7 +61,8 @@ class _SplashScreenState extends State<SplashScreen> {
         username == '' &&
         loggedInBefore == true) {
       Navigator.of(context).pushNamedAndRemoveUntil(
-          Routes.loginScreenRoute, (Route<dynamic> route) => false);
+          Routes.loginScreenRoute, (Route<dynamic> route) => false,
+          arguments: themeIndex);
     }
   }
 
@@ -63,7 +71,7 @@ class _SplashScreenState extends State<SplashScreen> {
     return Container(
       height: double.infinity,
       width: double.infinity,
-      color: ThemeProvider.theme(2).primaryColor,
+      color: ThemeProvider.theme(themeIndex).primaryColor,
       child: Center(
         child: Image(
           image: AssetImage(

--- a/lib/Route/route_generator.dart
+++ b/lib/Route/route_generator.dart
@@ -15,11 +15,17 @@ class RouteGenerator {
     final args = settings.arguments;
     switch (settings.name) {
       case Routes.splashScreenRoute:
-        return MaterialPageRoute(builder: (context) => SplashScreen());
+        final args = settings.arguments as int?;
+        return MaterialPageRoute(
+            builder: (context) => SplashScreen(themeIndex: args));
       case Routes.loginScreenRoute:
-        return MaterialPageRoute(builder: (context) => LoginScreen());
+        final args = settings.arguments as int?;
+        return MaterialPageRoute(
+            builder: (context) => LoginScreen(themeIndex: args));
       case Routes.homeScreenRoute:
-        return MaterialPageRoute(builder: (context) => HomeScreen());
+        final args = settings.arguments as int?;
+        return MaterialPageRoute(
+            builder: (context) => HomeScreen(themeIndex: args));
       case Routes.torrentContentScreenRoute:
         return MaterialPageRoute(
           builder: (context) => MultiProvider(
@@ -39,7 +45,9 @@ class RouteGenerator {
                   args: args as VideoStreamScreenArguments,
                 ));
       default:
-        return MaterialPageRoute(builder: (context) => LoginScreen());
+        final args = settings.arguments as int?;
+        return MaterialPageRoute(
+            builder: (context) => LoginScreen(themeIndex: args));
     }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:awesome_notifications/awesome_notifications.dart';
+import 'package:flood_mobile/Pages/splash_screen.dart';
 import 'package:flood_mobile/Provider/api_provider.dart';
 import 'package:flood_mobile/Provider/client_provider.dart';
 import 'package:flood_mobile/Constants/theme_provider.dart';
@@ -18,7 +19,6 @@ import 'Pages/home_screen.dart';
 import 'Provider/filter_provider.dart';
 import 'Provider/graph_provider.dart';
 import 'Route/route_generator.dart';
-import 'Route/routes.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -66,6 +66,7 @@ Future<void> main() async {
       AwesomeNotifications().requestPermissionToSendNotifications();
     }
   });
+  await ThemeProvider().getPreviousTheme();
   runApp(
     MyApp(),
   );
@@ -123,7 +124,14 @@ class MyApp extends StatelessWidget {
               navigatorKey: NavigationService.navigatorKey,
               debugShowCheckedModeBanner: false,
               title: 'Flutter Demo',
-              initialRoute: Routes.splashScreenRoute,
+              onGenerateInitialRoutes: (_) {
+                return [
+                  MaterialPageRoute(
+                    builder: (context) => SplashScreen(
+                        themeIndex: themeProvider.isDarkMode ? 2 : 1),
+                  ),
+                ];
+              },
               onGenerateRoute: RouteGenerator.generateRoute,
             ),
           );

--- a/test/widget_test/home_screen_widget_test.dart
+++ b/test/widget_test/home_screen_widget_test.dart
@@ -198,10 +198,8 @@ void main() {
       expect(find.byKey(Key("Change Theme Button")), findsNWidgets(2));
       expect(find.byIcon(Icons.wb_sunny_rounded), findsNWidgets(2));
       expect(find.byIcon(Icons.mode_night_rounded), findsNothing);
-      await tester.tap(find.byKey(Key("Change Theme Button")).last);
+      await tester.tap(find.byKey(Key("Change Theme Button")).first);
       await tester.pumpAndSettle();
-      expect(find.byIcon(Icons.wb_sunny_rounded), findsNothing);
-      expect(find.byIcon(Icons.mode_night_rounded), findsNWidgets(2));
       expect(find.byIcon(Icons.dashboard), findsNWidgets(2));
       expect(find.text("Torrents"), findsNWidgets(2));
       expect(find.byIcon(Icons.settings), findsNWidgets(2));


### PR DESCRIPTION
**Describe the changes you have made in this PR -**

- This pull request implements theme persistence throughout the app to ensure that the selected theme persists even when the app is closed and reopened. This feature provides a consistent user experience by remembering the chosen theme.
I stored the theme change value in `SharedPreferences` and utilized it when required.
Additionally, ensured that the theme on the `splash screen` and `login screen` remains the same as the previously selected theme.
- Tested the app thoroughly to ensure that the selected theme persists even after closing and reopening the app.
- Verified that the app maintains the selected theme across different screens.
