### PR TITLE
Added Undo button in delete snackbar

### DIFF
--- a/lib/Api/torrent_api.dart
+++ b/lib/Api/torrent_api.dart
@@ -17,6 +17,8 @@ import 'package:flood_mobile/Services/file_folder_nester.dart';
 import 'package:flood_mobile/l10n/l10n.dart';
 
 class TorrentApi {
+  static List<int>? undoDeletes;
+
   // Gets list of torrents
   static Stream<List<TorrentModel>> getAllTorrents(
       {required BuildContext context}) async* {
@@ -245,7 +247,7 @@ class TorrentApi {
       String url =
           BlocProvider.of<ApiBloc>(context, listen: false).state.baseUrl +
               ApiEndpoints.deleteTorrent;
-      print('---DELETE TORRENT---');
+      print('---STARTING DELETE---');
       print(url);
       Response response;
       Dio dio = new Dio();
@@ -260,6 +262,9 @@ class TorrentApi {
       mp['deleteData'] = deleteWithData;
       String rawBody = json.encode(mp);
       print(rawBody);
+      await Future.delayed(Duration(seconds: 4));
+      if (undoDeletes == id) return;
+      print('---DELETING TORRENT---');
       response = await dio.post(
         url,
         data: rawBody,
@@ -274,6 +279,14 @@ class TorrentApi {
       print('--ERROR IN TORRENT DELETE--');
       print(error.toString());
     }
+    undoDeletes = null;
+  }
+
+  static Future<void> undoDelete({
+    required List<int> id,
+  }) async {
+    print('---UNDO DELETE---');
+    undoDeletes = id;
   }
 
   static Stream<Map<String, dynamic>> getTorrentContent({

--- a/lib/Pages/widgets/flood_snackbar.dart
+++ b/lib/Pages/widgets/flood_snackbar.dart
@@ -9,8 +9,10 @@ enum SnackbarType {
 SnackBar addFloodSnackBar(
   SnackbarType snackbarType,
   String title,
-  String ctaText,
-) {
+  String ctaText, {
+  String? undoText,
+  VoidCallback? undoFunction,
+}) {
   return SnackBar(
     backgroundColor: snackbarType == SnackbarType.success
         ? Colors.greenAccent
@@ -18,6 +20,7 @@ SnackBar addFloodSnackBar(
             ? Colors.lightBlueAccent
             : Colors.orange,
     content: Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         Icon(
           snackbarType == SnackbarType.success
@@ -29,7 +32,7 @@ SnackBar addFloodSnackBar(
           size: 20,
         ),
         SizedBox(
-          width: 8,
+          width: undoText == null ? 8 : 12,
         ),
         Expanded(
           child: Text(
@@ -41,6 +44,27 @@ SnackBar addFloodSnackBar(
             ),
           ),
         ),
+        Visibility(
+          visible: undoText != null,
+          child: Row(
+            children: [
+              SizedBox(
+                width: 8,
+              ),
+              TextButton(
+                onPressed: undoFunction,
+                child: Text(
+                  undoText ?? "Undo",
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 2,
+                  style: TextStyle(
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        )
       ],
     ),
     action: SnackBarAction(

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -326,5 +326,6 @@
     "tag_selection_heading": "تفضيلات محدد الوسوم",
     "single_selection_radio_button": "اختيار واحد",
     "multi_selection_radio_button": "اختيار متعدد",
-    "show_progress_bar_option": "عرض شريط التقدم"
+    "show_progress_bar_option": "عرض شريط التقدم",
+    "button_undo": "تراجع" 
 }

--- a/lib/l10n/arb/app_cs.arb
+++ b/lib/l10n/arb/app_cs.arb
@@ -326,5 +326,6 @@
     "tag_selection_heading": "Předvolba výběru značek",
     "single_selection_radio_button": "Jednoduchý výběr",
     "multi_selection_radio_button": "Více výběrů",
-    "show_progress_bar_option": "Zobrazovat pruh postupu"
+    "show_progress_bar_option": "Zobrazovat pruh postupu",
+    "button_undo": "Zpět" 
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -325,5 +325,6 @@
     "sort_by_upload_speed": "Upload-Geschwindigkeit",
     "sort_by_file_size": "Dateigröße",
     "login_field_tooltip_message": "URL für Ihre Flood-Instanz (lokal, seedbox...)",
-    "sort_by_percent_completed": "Prozent abgeschlossen","show_progress_bar_option": "Fortschrittsbalken anzeigen"
+    "sort_by_percent_completed": "Prozent abgeschlossen","show_progress_bar_option": "Fortschrittsbalken anzeigen",
+    "button_undo": "Rückgängig" 
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -340,6 +340,7 @@
    "tag_selection_heading": "Tag Selector Preference",
    "single_selection_radio_button":"Single Selection",
    "multi_selection_radio_button":"Multi Selection",
-   "show_progress_bar_option":"Show Progress Bar"
+   "show_progress_bar_option":"Show Progress Bar",
+    "button_undo": "Undo" 
 }
   

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -326,5 +326,6 @@
     "tag_selection_heading": "Preferencia del selector de etiquetas",
     "single_selection_radio_button": "Selección única",
     "multi_selection_radio_button": "Selección múltiple",
-    "show_progress_bar_option": "Mostrar barra de progreso"
+    "show_progress_bar_option": "Mostrar barra de progreso",
+    "button_undo": "Deshacer" 
 }

--- a/lib/l10n/arb/app_fi.arb
+++ b/lib/l10n/arb/app_fi.arb
@@ -326,5 +326,6 @@
     "tag_selection_heading": "Tunnistevalitsimen asetukset",
     "single_selection_radio_button": "Yksittäinen valinta",
     "multi_selection_radio_button": "Useita valintoja",
-    "show_progress_bar_option": "Näytä edistymispalkki"
+    "show_progress_bar_option": "Näytä edistymispalkki",
+    "button_undo": "Kumoa" 
 }

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -327,5 +327,6 @@
     "tag_selection_heading": "Préférence du sélecteur de balises",
     "single_selection_radio_button": "Sélection unique",
     "multi_selection_radio_button": "Sélection multiple",
-    "show_progress_bar_option": "Afficher la barre de progression"
+    "show_progress_bar_option": "Afficher la barre de progression",
+    "button_undo": "Annuler" 
 }

--- a/lib/l10n/arb/app_hi.arb
+++ b/lib/l10n/arb/app_hi.arb
@@ -326,5 +326,6 @@
     "tag_selection_heading": "टैग सिलेक्शन प्राथमिकता",
     "single_selection_radio_button": "एकल चयन",
     "multi_selection_radio_button": "बहुविकल्पी चयन",
-    "show_progress_bar_option": "प्रगति संकेतक दिखाएं"
+    "show_progress_bar_option": "प्रगति संकेतक दिखाएं",
+    "button_undo": "पूर्ववत करें" 
 }

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -326,5 +326,6 @@
     "tag_selection_heading": "Címkeválasztó előnyben részesítése",
     "single_selection_radio_button": "Egyszeres kiválasztás",
     "multi_selection_radio_button": "Többszörös kiválasztás",
-    "show_progress_bar_option": "Folyamatjelző megjelenítése"
+    "show_progress_bar_option": "Folyamatjelző megjelenítése",
+    "button_undo": "Visszavonás" 
 }

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -326,5 +326,6 @@
     "tag_selection_heading": "Preferenza del selettore di tag",
     "single_selection_radio_button": "Selezione singola",
     "multi_selection_radio_button": "Selezione multipla",
-    "show_progress_bar_option": "Mostra barra di avanzamento"
+    "show_progress_bar_option": "Mostra barra di avanzamento",
+    "button_undo": "Annulla" 
 }

--- a/lib/l10n/arb/app_ja.arb
+++ b/lib/l10n/arb/app_ja.arb
@@ -327,5 +327,6 @@
     "tag_selection_heading": "タグセレクターの設定",
     "single_selection_radio_button": "単一選択",
     "multi_selection_radio_button": "複数選択",
-    "show_progress_bar_option": "プログレスバーを表示"
+    "show_progress_bar_option": "プログレスバーを表示",
+    "button_undo": "元に戻す" 
 }

--- a/lib/l10n/arb/app_ko.arb
+++ b/lib/l10n/arb/app_ko.arb
@@ -326,5 +326,6 @@
     "tag_selection_heading": "태그 선택기 기본 설정",
     "single_selection_radio_button": "단일 선택",
     "multi_selection_radio_button": "다중 선택",
-    "show_progress_bar_option": "진행 상황 표시"
+    "show_progress_bar_option": "진행 상황 표시",
+    "button_undo": "취소." 
 }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -326,5 +326,6 @@
     "tag_selection_heading": "Voorkeur voor tagselectie",
     "single_selection_radio_button": "Enkele selectie",
     "multi_selection_radio_button": "Meervoudige selectie",
-    "show_progress_bar_option": "Voortgangsbalk weergeven"
+    "show_progress_bar_option": "Voortgangsbalk weergeven",
+    "button_undo": "Ongedaan maken" 
 }

--- a/lib/l10n/arb/app_no.arb
+++ b/lib/l10n/arb/app_no.arb
@@ -326,5 +326,6 @@
     "tag_selection_heading": "Foretrukket tagvelger",
     "single_selection_radio_button": "Enkeltvalg",
     "multi_selection_radio_button": "Flervalg",
-    "show_progress_bar_option": "Vis fremdriftslinje"
+    "show_progress_bar_option": "Vis fremdriftslinje",
+    "button_undo": "Angre" 
 }

--- a/lib/l10n/arb/app_pl.arb
+++ b/lib/l10n/arb/app_pl.arb
@@ -326,5 +326,6 @@
     "tag_selection_heading": "Preferencje wyboru tagów",
     "single_selection_radio_button": "Pojedynczy wybór",
     "multi_selection_radio_button": "Wielokrotny wybór",
-    "show_progress_bar_option": "Pokaż pasek postępu"
+    "show_progress_bar_option": "Pokaż pasek postępu",
+    "button_undo": "Cofnij" 
 }

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -326,5 +326,6 @@
     "tag_selection_heading": "Preferência do seletor de tags",
     "single_selection_radio_button": "Seleção única",
     "multi_selection_radio_button": "Seleção múltipla",
-    "show_progress_bar_option": "Mostrar barra de progresso"
+    "show_progress_bar_option": "Mostrar barra de progresso",
+    "button_undo": "Desfazer" 
 }

--- a/lib/l10n/arb/app_ro.arb
+++ b/lib/l10n/arb/app_ro.arb
@@ -326,5 +326,6 @@
     "tag_selection_heading": "Preferință pentru selector de etichete",
     "single_selection_radio_button": "Selecție unică",
     "multi_selection_radio_button": "Selecție multiplă",
-    "show_progress_bar_option": "Afișează bara de progres"
+    "show_progress_bar_option": "Afișează bara de progres",
+    "button_undo": "Anulează" 
 }

--- a/lib/l10n/arb/app_ru.arb
+++ b/lib/l10n/arb/app_ru.arb
@@ -326,5 +326,6 @@
     "tag_selection_heading": "Предпочтение селектора тегов",
     "single_selection_radio_button": "Одиночный выбор",
     "multi_selection_radio_button": "Множественный выбор",
-    "show_progress_bar_option": "Показывать полосу прогресса"
+    "show_progress_bar_option": "Показывать полосу прогресса",
+    "button_undo": "Отменить" 
 }

--- a/lib/l10n/arb/app_sv.arb
+++ b/lib/l10n/arb/app_sv.arb
@@ -327,5 +327,6 @@
     "tag_selection_heading": "Taggväljarinställning",
     "single_selection_radio_button": "Enkelval",
     "multi_selection_radio_button": "Flerval",
-    "show_progress_bar_option": "Visa framstegsindikator"
+    "show_progress_bar_option": "Visa framstegsindikator",
+    "button_undo": "Ångra" 
 }

--- a/lib/l10n/arb/app_uk.arb
+++ b/lib/l10n/arb/app_uk.arb
@@ -327,5 +327,6 @@
     "tag_selection_heading": "Пріоритет вибору тегів",
     "single_selection_radio_button": "Одиночний вибір",
     "multi_selection_radio_button": "Множинний вибір",
-    "show_progress_bar_option": "Показати панель прогресу"
+    "show_progress_bar_option": "Показати панель прогресу",
+    "button_undo": "Скасувати" 
 }

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -327,5 +327,6 @@
     "tag_selection_heading": "标签选择器优先级",
     "single_selection_radio_button": "单选",
     "multi_selection_radio_button": "多选",
-    "show_progress_bar_option": "显示进度条"
+    "show_progress_bar_option": "显示进度条",
+    "button_undo": "撤销" 
 }


### PR DESCRIPTION
Ref #113

Describe the changes you have made in this PR:
- Added an Undo button in Delete Torrent Snackbar, which allows the user to undo their delete operation for 4 seconds (the duration of the snackbar).
- Added localization for the "Undo" button to support multiple languages. 

Screenshots of the changes (If any):

<img width="227" alt="image" src="https://github.com/CCExtractor/Flood_Mobile/assets/58645688/781d894b-6df4-49f3-a7ce-52be8039f1c5">
