### PR TITLE
Replaced deprecated WillPopScope with PopScope

### DIFF
--- a/lib/Pages/home_screen/home_screen.dart
+++ b/lib/Pages/home_screen/home_screen.dart
@@ -217,9 +217,7 @@ class _HomeScreenState extends State<HomeScreen> {
                         final selectedTorrent =
                             BlocProvider.of<MultipleSelectTorrentBloc>(context,
                                 listen: false);
-                        return WillPopScope(
-                          onWillPop: () =>
-                              onBackPressed(timeBackPressed, context),
+                        return PopScope(
                           child: Scaffold(
                             appBar: AppBar(
                               key: Key('AppBar $themeIndex'),


### PR DESCRIPTION
Describe the changes you have made in this PR -
- I updated how we handle the back button in the app.
- The old way was causing warnings and might not work in future updates, so we switched to a newer method called PopScope.
- This change helps keep our code up-to-date and ensures things keep working smoothly in the future.

Screenshots of the changes (If any) -

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.
